### PR TITLE
Uses bullseye in portable_epubs example

### DIFF
--- a/examples/portable_epubs/portable_epubs.typ
+++ b/examples/portable_epubs/portable_epubs.typ
@@ -1,9 +1,13 @@
-#let custom-element(name) = (attrs: (:), body) => context {
-  if target() == "html" {
+#import "@preview/bullseye:0.1.0": *
+
+#let custom-element(name) = (attrs: (:), body) => {
+  context on-target(html: {
     html.elem(name, attrs: attrs, body)
-  } else {
-    block(children)
-  }
+  })
+
+  context on-target(paged: {
+    block(body)
+  })
 }
 
 #let header = custom-element("header")


### PR DESCRIPTION
The basic `just build examples/portable_epub` command wasn't working for me due to the conditional block. (Was it working for you @willcrichton, or was it a work-in-progress?)

I've been using bullseye for conditional target rendering, as it doesn't seem to throw up the same issues as the `if target()` approach.