### PR TITLE
Ignores .beads folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 # Nix build artifacts
 result
 result-*
+
+# Beads database and daemon files
+.beads/

--- a/flake.nix
+++ b/flake.nix
@@ -20,11 +20,16 @@
         craneLib = crane.mkLib pkgs;
 
         # Source filtering to include Cargo files and resources in src/
+        # Exclude .beads directory to avoid socket file issues
         src = pkgs.lib.cleanSourceWith {
           src = craneLib.path ./.;
           filter = path: type:
-            (craneLib.filterCargoSources path type) ||
-            (pkgs.lib.hasInfix "/src/" path);
+            let
+              baseName = baseNameOf path;
+            in
+            (baseName != ".beads") &&
+            ((craneLib.filterCargoSources path type) ||
+            (pkgs.lib.hasInfix "/src/" path));
         };
 
         # Build *just* the cargo dependencies (for caching)


### PR DESCRIPTION
The `.beads` folder is causing issues in the Nix flake. But I also don't think I want to track it at all in version control, as it's an implementation detail for how I personally write code.