### PR TITLE
Defaults to reasonable font

### DIFF
--- a/src/typ/rheo.typ
+++ b/src/typ/rheo.typ
@@ -26,4 +26,4 @@
 }
 
 // Set a default font
-#set text(font: ("Inter", "San Francisco", "Arial", "Helvetica"))
+#set text(font: ("Times New Roman", "Arial", "Helvetica"))


### PR DESCRIPTION
This is necessary for MacOS. Closes #74.