### PR TITLE
Defaults to Libertinus Serif as default font

### DIFF
--- a/src/typ/rheo.typ
+++ b/src/typ/rheo.typ
@@ -25,5 +25,5 @@
   doc
 }
 
-// Set a default font
-#set text(font: ("Times New Roman", "Arial", "Helvetica"))
+// Libertinus Serif is embedded in Typst, so we can rely on it always being available. Any subsequent font declarations will override this. 
+#set text(font: "Libertinus Serif")


### PR DESCRIPTION
Closes #83, as 'Libertinus Serif' is embedded in the Typst compiler.