### PR TITLE
Fixes permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
   publish-crates:
     needs: build-artifacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The [v0.1.2 release automation](https://github.com/freecomputinglab/rheo/actions/runs/21908516820) failed on account of there being no write permissions in the GitHub action. I have created the tag on the merge commit manually, as well as the GH release that was blocked by the failure. For the next release (v0.1.3), this fix should allow the automation to work. 