### PR TITLE
Fix broken import paths on `merge = true`

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -554,7 +554,6 @@ fn perform_compilation(
             if let Some(ref mut existing_world) = world {
                 for typ_file in &files {
                     existing_world.set_main(typ_file)?;
-                    existing_world.reset();
                     compile_one_file(existing_world, typ_file, &pfc, &mut results)?;
                 }
             } else {

--- a/crates/core/src/reticulate/parser.rs
+++ b/crates/core/src/reticulate/parser.rs
@@ -14,29 +14,59 @@ pub type WrapperMap = HashMap<String, usize>;
 /// Also detects same-file wrapper functions (`#let f(x) = link(x, ...)`) so
 /// that calls like `#f("url")` are recognised as links.
 pub fn extract_links(source: &Source) -> Vec<LinkInfo> {
+    extract_nodes(source).links
+}
+
+/// Extract all import/include paths from Typst source by parsing and
+/// traversing AST.
+pub fn extract_imports(source: &Source) -> Vec<ImportInfo> {
+    extract_nodes(source).imports
+}
+
+/// Result of a single-pass AST extraction.
+pub struct ExtractedNodes {
+    pub links: Vec<LinkInfo>,
+    pub imports: Vec<ImportInfo>,
+}
+
+/// Single-pass extraction of both links and imports from Typst source.
+///
+/// Parses the source exactly once and traverses the AST once to collect
+/// both link info and import info.
+pub fn extract_nodes(source: &Source) -> ExtractedNodes {
     let root = typst::syntax::parse(source.text());
     let wrappers = collect_link_wrappers(&root);
     let mut links = Vec::new();
-    extract_links_from_node(&root, &root, &mut links, &wrappers);
-    links
+    let mut imports = Vec::new();
+    extract_from_node(&root, &root, &mut links, &mut imports, &wrappers);
+    ExtractedNodes { links, imports }
 }
 
-fn extract_links_from_node(
+/// Combined single-pass traversal that collects both links and imports.
+fn extract_from_node(
     node: &SyntaxNode,
     root: &SyntaxNode,
     links: &mut Vec<LinkInfo>,
+    imports: &mut Vec<ImportInfo>,
     wrappers: &WrapperMap,
 ) {
-    // Check if this node itself is a function call
+    // Collect link info from function calls
     if node.kind() == SyntaxKind::FuncCall
         && let Some(link_info) = parse_link_call(node, root, wrappers)
     {
         links.push(link_info);
     }
 
+    // Collect import/include info
+    if (node.kind() == SyntaxKind::ModuleImport || node.kind() == SyntaxKind::ModuleInclude)
+        && let Some(import_info) = parse_import_node(node, root)
+    {
+        imports.push(import_info);
+    }
+
     // Recursively traverse children
     for child in node.children() {
-        extract_links_from_node(child, root, links, wrappers);
+        extract_from_node(child, root, links, imports, wrappers);
     }
 }
 
@@ -290,34 +320,7 @@ fn find_link_call(node: &SyntaxNode) -> Option<&SyntaxNode> {
     None
 }
 
-// ---------------------------------------------------------------------------
-// Import/include extraction
-// ---------------------------------------------------------------------------
-
-/// Extract all import/include paths from Typst source by parsing and traversing AST
-pub fn extract_imports(source: &Source) -> Vec<ImportInfo> {
-    let root = typst::syntax::parse(source.text());
-    let mut imports = Vec::new();
-    extract_imports_from_node(&root, &root, &mut imports);
-    imports
-}
-
-fn extract_imports_from_node(
-    node: &SyntaxNode,
-    root: &SyntaxNode,
-    imports: &mut Vec<ImportInfo>,
-) {
-    if (node.kind() == SyntaxKind::ModuleImport || node.kind() == SyntaxKind::ModuleInclude)
-        && let Some(import_info) = parse_import_node(node, root)
-    {
-        imports.push(import_info);
-    }
-
-    for child in node.children() {
-        extract_imports_from_node(child, root, imports);
-    }
-}
-
+/// Parse a ModuleImport or ModuleInclude node into ImportInfo.
 fn parse_import_node(node: &SyntaxNode, root: &SyntaxNode) -> Option<ImportInfo> {
     // Find the first Str child — that is the path argument
     let str_node = node.children().find(|n| n.kind() == SyntaxKind::Str)?;

--- a/crates/core/src/reticulate/parser.rs
+++ b/crates/core/src/reticulate/parser.rs
@@ -1,7 +1,6 @@
 use crate::reticulate::types::{ImportInfo, LinkInfo};
 use crate::reticulate::validator::is_relative_typ_link;
 use std::collections::HashMap;
-use std::ops::Range;
 use typst::syntax::{Source, SyntaxKind, SyntaxNode};
 
 /// The identifier in the Typst AST for links.
@@ -143,10 +142,7 @@ fn parse_link_call(
 }
 
 /// Return the text and node reference of the n-th positional `Str` argument.
-fn extract_nth_string_arg_with_node(
-    args: &SyntaxNode,
-    n: usize,
-) -> Option<(String, &SyntaxNode)> {
+fn extract_nth_string_arg_with_node(args: &SyntaxNode, n: usize) -> Option<(String, &SyntaxNode)> {
     let mut pos = 0;
     for child in args.children() {
         // Skip structural tokens and named args
@@ -189,17 +185,6 @@ fn extract_nth_ident_arg(args: &SyntaxNode, n: usize) -> Option<String> {
             return None;
         }
         pos += 1;
-    }
-    None
-}
-
-fn extract_first_string_arg(args: &SyntaxNode) -> Option<String> {
-    for child in args.children() {
-        if child.kind() == SyntaxKind::Str {
-            // Remove quotes
-            let text = child.text();
-            return Some(text.trim_matches('"').to_string());
-        }
     }
     None
 }
@@ -270,7 +255,10 @@ fn try_register_wrapper(let_binding: &SyntaxNode, map: &mut WrapperMap) {
     // Case 1: Closure wrapper — #let f(x, y) = link(x, y)
     // The Closure is a direct child of LetBinding; the function name Ident
     // lives *inside* the Closure, not as a direct child of LetBinding.
-    if let Some(closure) = let_binding.children().find(|c| c.kind() == SyntaxKind::Closure) {
+    if let Some(closure) = let_binding
+        .children()
+        .find(|c| c.kind() == SyntaxKind::Closure)
+    {
         register_closure_wrapper(closure, map);
         return;
     }
@@ -409,11 +397,11 @@ fn collect_url_bindings_from_node(
             }
             if after_eq && child.kind() == SyntaxKind::Str {
                 let text = child.text().trim_matches('"').to_string();
-                if is_relative_typ_link(&text) {
-                    if let Some(offset) = calculate_node_offset(root, child) {
-                        let byte_range = offset..(offset + child.len());
-                        map.insert(binding_name, (text, byte_range));
-                    }
+                if is_relative_typ_link(&text)
+                    && let Some(offset) = calculate_node_offset(root, child)
+                {
+                    let byte_range = offset..(offset + child.len());
+                    map.insert(binding_name, (text, byte_range));
                 }
                 break;
             }
@@ -552,8 +540,10 @@ mod tests {
 
     #[test]
     fn test_wrapper_direct_alias() {
-        let source = Source::detached(r#"#let mylink = link
-#mylink("./chapter2.typ")[text]"#);
+        let source = Source::detached(
+            r#"#let mylink = link
+#mylink("./chapter2.typ")[text]"#,
+        );
         let links = extract_links(&source);
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].url, "./chapter2.typ");

--- a/crates/core/src/reticulate/parser.rs
+++ b/crates/core/src/reticulate/parser.rs
@@ -33,6 +33,10 @@ pub fn extract_imports(source: &Source) -> Vec<ImportInfo> {
 pub struct ExtractedNodes {
     pub links: Vec<LinkInfo>,
     pub imports: Vec<ImportInfo>,
+    /// 1-based line numbers of `#link()` calls whose first URL argument could
+    /// not be statically resolved (not a string literal, not a resolved
+    /// let-binding, not a label reference).
+    pub unresolvable_link_lines: Vec<usize>,
 }
 
 /// Single-pass extraction of both links and imports from Typst source.
@@ -45,31 +49,43 @@ pub fn extract_nodes(source: &Source) -> ExtractedNodes {
     let url_bindings = collect_url_bindings(&root);
     let mut links = Vec::new();
     let mut imports = Vec::new();
+    let mut unresolvable_link_lines = Vec::new();
     extract_from_node(
         &root,
         &root,
+        source.text(),
         &mut links,
         &mut imports,
+        &mut unresolvable_link_lines,
         &wrappers,
         &url_bindings,
     );
-    ExtractedNodes { links, imports }
+    ExtractedNodes {
+        links,
+        imports,
+        unresolvable_link_lines,
+    }
 }
 
 /// Combined single-pass traversal that collects both links and imports.
+#[allow(clippy::too_many_arguments)]
 fn extract_from_node(
     node: &SyntaxNode,
     root: &SyntaxNode,
+    source_text: &str,
     links: &mut Vec<LinkInfo>,
     imports: &mut Vec<ImportInfo>,
+    unresolvable: &mut Vec<usize>,
     wrappers: &WrapperMap,
     url_bindings: &UrlBindingMap,
 ) {
     // Collect link info from function calls
-    if node.kind() == SyntaxKind::FuncCall
-        && let Some(link_info) = parse_link_call(node, root, wrappers, url_bindings)
-    {
-        links.push(link_info);
+    if node.kind() == SyntaxKind::FuncCall {
+        if let Some(link_info) = parse_link_call(node, root, wrappers, url_bindings) {
+            links.push(link_info);
+        } else {
+            collect_unresolvable_link(node, root, source_text, url_bindings, unresolvable);
+        }
     }
 
     // Collect import/include info
@@ -81,7 +97,74 @@ fn extract_from_node(
 
     // Recursively traverse children
     for child in node.children() {
-        extract_from_node(child, root, links, imports, wrappers, url_bindings);
+        extract_from_node(
+            child,
+            root,
+            source_text,
+            links,
+            imports,
+            unresolvable,
+            wrappers,
+            url_bindings,
+        );
+    }
+}
+
+/// Check whether a FuncCall node is a direct `#link()` call with an unresolvable
+/// first argument, and if so record the 1-based line number.
+fn collect_unresolvable_link(
+    func_call: &SyntaxNode,
+    root: &SyntaxNode,
+    text: &str,
+    url_bindings: &UrlBindingMap,
+    results: &mut Vec<usize>,
+) {
+    // Only direct `#link(...)` calls, not unknown wrapper calls.
+    let Some(ident) = func_call
+        .children()
+        .find(|n| n.kind() == SyntaxKind::Ident)
+    else {
+        return;
+    };
+    if ident.text() != LINK_IDENT_ID {
+        return;
+    }
+
+    let Some(args) = func_call
+        .children()
+        .find(|n| n.kind() == SyntaxKind::Args)
+    else {
+        return;
+    };
+
+    // First positional argument (skip parens, commas, spaces, named args).
+    let first = args.children().find(|c| {
+        !matches!(
+            c.kind(),
+            SyntaxKind::LeftParen
+                | SyntaxKind::RightParen
+                | SyntaxKind::Comma
+                | SyntaxKind::Space
+                | SyntaxKind::Named
+        )
+    });
+    let Some(first) = first else { return };
+
+    let is_unresolvable = match first.kind() {
+        SyntaxKind::Str => false,   // literal string — resolved
+        SyntaxKind::Label => false, // label reference — valid non-string target
+        SyntaxKind::Ident => !url_bindings.contains_key(first.text().as_str()),
+        _ => true, // FuncCall, BinaryOp, etc.
+    };
+
+    if is_unresolvable {
+        let line = calculate_node_offset(root, func_call)
+            .map(|offset| {
+                let safe = offset.min(text.len());
+                text[..safe].lines().count().max(1)
+            })
+            .unwrap_or(1);
+        results.push(line);
     }
 }
 

--- a/crates/core/src/reticulate/parser.rs
+++ b/crates/core/src/reticulate/parser.rs
@@ -1,65 +1,118 @@
 use crate::reticulate::types::{ImportInfo, LinkInfo};
+use std::collections::HashMap;
 use typst::syntax::{Source, SyntaxKind, SyntaxNode};
 
 /// The identifier in the Typst AST for links.
 const LINK_IDENT_ID: &str = "link";
 
-/// Extract all links from Typst source by parsing and traversing AST
+/// Maps a wrapper function name to the index of its parameter that is passed
+/// as the URL to the inner `link()` call.
+pub type WrapperMap = HashMap<String, usize>;
+
+/// Extract all links from Typst source by parsing and traversing AST.
+///
+/// Also detects same-file wrapper functions (`#let f(x) = link(x, ...)`) so
+/// that calls like `#f("url")` are recognised as links.
 pub fn extract_links(source: &Source) -> Vec<LinkInfo> {
     let root = typst::syntax::parse(source.text());
+    let wrappers = collect_link_wrappers(&root);
     let mut links = Vec::new();
-    extract_links_from_node(&root, &root, &mut links);
+    extract_links_from_node(&root, &root, &mut links, &wrappers);
     links
 }
 
-fn extract_links_from_node(node: &SyntaxNode, root: &SyntaxNode, links: &mut Vec<LinkInfo>) {
+fn extract_links_from_node(
+    node: &SyntaxNode,
+    root: &SyntaxNode,
+    links: &mut Vec<LinkInfo>,
+    wrappers: &WrapperMap,
+) {
     // Check if this node itself is a function call
     if node.kind() == SyntaxKind::FuncCall
-        && let Some(link_info) = parse_link_call(node, root)
+        && let Some(link_info) = parse_link_call(node, root, wrappers)
     {
         links.push(link_info);
     }
 
     // Recursively traverse children
     for child in node.children() {
-        extract_links_from_node(child, root, links);
+        extract_links_from_node(child, root, links, wrappers);
     }
 }
 
-fn parse_link_call(node: &SyntaxNode, root: &SyntaxNode) -> Option<LinkInfo> {
-    // Parse #link("url")[body] or #link("url", body)
-    // Extract:
-    // 1. Function name (must be "link")
-    // 2. URL argument (first string argument)
-    // 3. Body text (from content block or second argument)
-    // 4. Byte range by calculating AST node position
-
+fn parse_link_call(
+    node: &SyntaxNode,
+    root: &SyntaxNode,
+    wrappers: &WrapperMap,
+) -> Option<LinkInfo> {
     let ident = node.children().find(|n| n.kind() == SyntaxKind::Ident)?;
-    if ident.text() != LINK_IDENT_ID {
+
+    let (url_param_index, is_wrapper) = if ident.text() == LINK_IDENT_ID {
+        (0, false)
+    } else if let Some(&idx) = wrappers.get(ident.text().as_str()) {
+        (idx, true)
+    } else {
         return None;
-    }
+    };
 
     let args = node.children().find(|n| n.kind() == SyntaxKind::Args)?;
 
-    // Extract URL (first string argument)
-    let url = extract_first_string_arg(args)?;
+    if is_wrapper {
+        // Wrapper call: byte range covers only the Str argument
+        let (url, str_node) = extract_nth_string_arg_with_node(args, url_param_index)?;
+        let offset = calculate_node_offset(root, str_node)?;
+        let byte_range = offset..(offset + str_node.len());
 
-    // Extract body text
-    let body = extract_link_body(node)?;
+        Some(LinkInfo {
+            url,
+            body: String::new(),
+            span: node.span(),
+            byte_range,
+            is_wrapper_call: true,
+        })
+    } else {
+        // Standard link() call: byte range covers the full expression
+        let url = extract_first_string_arg(args)?;
+        let body = extract_link_body(node)?;
+        let offset = calculate_node_offset(root, node)?;
+        let byte_range = offset..(offset + node.len());
 
-    // Calculate byte range directly from AST node position
-    let offset = calculate_node_offset(root, node)?;
-    let byte_range = offset..(offset + node.len());
+        Some(LinkInfo {
+            url,
+            body,
+            span: node.span(),
+            byte_range,
+            is_wrapper_call: false,
+        })
+    }
+}
 
-    // Get span for error reporting
-    let span = node.span();
-
-    Some(LinkInfo {
-        url,
-        body,
-        span,
-        byte_range,
-    })
+/// Return the text and node reference of the n-th positional `Str` argument.
+fn extract_nth_string_arg_with_node(
+    args: &SyntaxNode,
+    n: usize,
+) -> Option<(String, &SyntaxNode)> {
+    let mut pos = 0;
+    for child in args.children() {
+        // Skip structural tokens and named args
+        match child.kind() {
+            SyntaxKind::LeftParen
+            | SyntaxKind::RightParen
+            | SyntaxKind::Comma
+            | SyntaxKind::Space
+            | SyntaxKind::Named => continue,
+            _ => {}
+        }
+        if pos == n {
+            if child.kind() == SyntaxKind::Str {
+                let text = child.text().trim_matches('"').to_string();
+                return Some((text, child));
+            }
+            return None; // n-th positional arg is not a string
+        }
+        pos += 1;
+    }
+    None
 }
 
 fn extract_first_string_arg(args: &SyntaxNode) -> Option<String> {
@@ -114,6 +167,132 @@ fn extract_text_from_node(node: &SyntaxNode) -> Option<String> {
         Some(texts.join(""))
     }
 }
+
+// ---------------------------------------------------------------------------
+// Wrapper-function detection
+// ---------------------------------------------------------------------------
+
+/// First-pass scan: collect all same-file function definitions that wrap `link()`.
+pub fn collect_link_wrappers(root: &SyntaxNode) -> WrapperMap {
+    let mut map = HashMap::new();
+    collect_wrappers_from_node(root, &mut map);
+    map
+}
+
+fn collect_wrappers_from_node(node: &SyntaxNode, map: &mut WrapperMap) {
+    if node.kind() == SyntaxKind::LetBinding {
+        try_register_wrapper(node, map);
+    }
+    for child in node.children() {
+        collect_wrappers_from_node(child, map);
+    }
+}
+
+fn try_register_wrapper(let_binding: &SyntaxNode, map: &mut WrapperMap) {
+    // Case 1: Closure wrapper — #let f(x, y) = link(x, y)
+    // The Closure is a direct child of LetBinding; the function name Ident
+    // lives *inside* the Closure, not as a direct child of LetBinding.
+    if let Some(closure) = let_binding.children().find(|c| c.kind() == SyntaxKind::Closure) {
+        register_closure_wrapper(closure, map);
+        return;
+    }
+
+    // Case 2: Direct alias — #let mylink = link
+    let idents: Vec<_> = let_binding
+        .children()
+        .filter(|c| c.kind() == SyntaxKind::Ident)
+        .collect();
+
+    if idents.len() < 2 {
+        return;
+    }
+
+    let fn_name = idents[0].text().to_string();
+    let has_link_alias = idents.iter().skip(1).any(|c| c.text() == LINK_IDENT_ID);
+    if has_link_alias {
+        map.insert(fn_name, 0);
+    }
+}
+
+fn register_closure_wrapper(closure: &SyntaxNode, map: &mut WrapperMap) {
+    // Function name is the first Ident child of the Closure
+    let fn_name_node = match closure.children().find(|c| c.kind() == SyntaxKind::Ident) {
+        Some(n) => n,
+        None => return,
+    };
+    let fn_name = fn_name_node.text().to_string();
+
+    let Some(params_node) = closure.children().find(|c| c.kind() == SyntaxKind::Params) else {
+        return;
+    };
+
+    let param_names: Vec<String> = params_node
+        .children()
+        .filter(|c| c.kind() == SyntaxKind::Ident)
+        .map(|c| c.text().to_string())
+        .collect();
+
+    let Some(link_call) = find_link_call(closure) else {
+        return;
+    };
+
+    let Some(args) = link_call.children().find(|c| c.kind() == SyntaxKind::Args) else {
+        return;
+    };
+
+    // Get first positional arg of link()
+    let first_pos_arg = args.children().find(|c| {
+        !matches!(
+            c.kind(),
+            SyntaxKind::LeftParen
+                | SyntaxKind::RightParen
+                | SyntaxKind::Comma
+                | SyntaxKind::Space
+                | SyntaxKind::Named
+        )
+    });
+
+    let Some(first_arg) = first_pos_arg else {
+        return;
+    };
+
+    // If first arg is a Str, the URL is hardcoded in the wrapper — skip
+    if first_arg.kind() == SyntaxKind::Str {
+        return;
+    }
+
+    // Must be an Ident matching a param
+    if first_arg.kind() != SyntaxKind::Ident {
+        return;
+    }
+
+    let arg_name = first_arg.text();
+    let Some(param_idx) = param_names.iter().position(|n| n == arg_name.as_str()) else {
+        return;
+    };
+
+    map.insert(fn_name, param_idx);
+}
+
+/// Find the first `FuncCall` to `link()` inside a subtree.
+fn find_link_call(node: &SyntaxNode) -> Option<&SyntaxNode> {
+    if node.kind() == SyntaxKind::FuncCall {
+        let ident = node.children().find(|c| c.kind() == SyntaxKind::Ident)?;
+        if ident.text() == LINK_IDENT_ID {
+            return Some(node);
+        }
+    }
+    for child in node.children() {
+        if let Some(found) = find_link_call(child) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Import/include extraction
+// ---------------------------------------------------------------------------
 
 /// Extract all import/include paths from Typst source by parsing and traversing AST
 pub fn extract_imports(source: &Source) -> Vec<ImportInfo> {
@@ -196,6 +375,7 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].url, "./file.typ");
         assert_eq!(links[0].body, "text");
+        assert!(!links[0].is_wrapper_call);
     }
 
     #[test]
@@ -241,7 +421,6 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].url, "./url");
         assert_eq!(links[0].body, "text 2"); // All text concatenated
-        // Byte range should cover the entire link (exact start may vary by 1 due to Source::detached)
         assert!(links[0].byte_range.len() >= 29);
     }
 
@@ -253,6 +432,48 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].url, "url");
         assert_eq!(links[0].body, "bold and italic");
+    }
+
+    // --- Wrapper function tests ---
+
+    #[test]
+    fn test_wrapper_direct_alias() {
+        let source = Source::detached(r#"#let mylink = link
+#mylink("./chapter2.typ")[text]"#);
+        let links = extract_links(&source);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].url, "./chapter2.typ");
+        assert!(links[0].is_wrapper_call);
+    }
+
+    #[test]
+    fn test_wrapper_closure() {
+        let source = Source::detached(
+            r#"#let chapter-ref(path, title) = link(path, title)
+#chapter-ref("./ch02.typ", [Chapter 2])"#,
+        );
+        let links = extract_links(&source);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].url, "./ch02.typ");
+        assert!(links[0].is_wrapper_call);
+    }
+
+    #[test]
+    fn test_wrapper_cross_file_not_detected() {
+        let source = Source::detached(r#"#chapter-ref("./ch02.typ", [Ch 2])"#);
+        let links = extract_links(&source);
+        assert_eq!(links.len(), 0);
+    }
+
+    #[test]
+    fn test_wrapper_hardcoded_url_skipped() {
+        // If link() is called with a hardcoded URL, nothing to rewrite at call site
+        let source = Source::detached(
+            r#"#let homepage(body) = link("https://example.com", body)
+#homepage[text]"#,
+        );
+        let links = extract_links(&source);
+        assert_eq!(links.len(), 0);
     }
 
     // --- extract_imports tests ---
@@ -313,7 +534,6 @@ mod tests {
         let imports = extract_imports(&source);
 
         assert_eq!(imports.len(), 1);
-        // byte_range should cover the Str node including quotes
         let source_text = source.text();
         let range_text = &source_text[imports[0].byte_range.clone()];
         assert_eq!(range_text, "\"./utils.typ\"");

--- a/crates/core/src/reticulate/parser.rs
+++ b/crates/core/src/reticulate/parser.rs
@@ -1,4 +1,4 @@
-use crate::reticulate::types::LinkInfo;
+use crate::reticulate::types::{ImportInfo, LinkInfo};
 use typst::syntax::{Source, SyntaxKind, SyntaxNode};
 
 /// The identifier in the Typst AST for links.
@@ -115,6 +115,47 @@ fn extract_text_from_node(node: &SyntaxNode) -> Option<String> {
     }
 }
 
+/// Extract all import/include paths from Typst source by parsing and traversing AST
+pub fn extract_imports(source: &Source) -> Vec<ImportInfo> {
+    let root = typst::syntax::parse(source.text());
+    let mut imports = Vec::new();
+    extract_imports_from_node(&root, &root, &mut imports);
+    imports
+}
+
+fn extract_imports_from_node(
+    node: &SyntaxNode,
+    root: &SyntaxNode,
+    imports: &mut Vec<ImportInfo>,
+) {
+    if (node.kind() == SyntaxKind::ModuleImport || node.kind() == SyntaxKind::ModuleInclude)
+        && let Some(import_info) = parse_import_node(node, root)
+    {
+        imports.push(import_info);
+    }
+
+    for child in node.children() {
+        extract_imports_from_node(child, root, imports);
+    }
+}
+
+fn parse_import_node(node: &SyntaxNode, root: &SyntaxNode) -> Option<ImportInfo> {
+    // Find the first Str child — that is the path argument
+    let str_node = node.children().find(|n| n.kind() == SyntaxKind::Str)?;
+
+    let text = str_node.text();
+    let path = text.trim_matches('"').to_string();
+
+    let offset = calculate_node_offset(root, str_node)?;
+    let byte_range = offset..(offset + str_node.len());
+
+    Some(ImportInfo {
+        is_package: path.starts_with('@'),
+        path,
+        byte_range,
+    })
+}
+
 /// Calculate the byte offset of a target node within the root AST
 fn calculate_node_offset(root: &SyntaxNode, target: &SyntaxNode) -> Option<usize> {
     calculate_node_offset_impl(root, target, 0)
@@ -212,5 +253,77 @@ mod tests {
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].url, "url");
         assert_eq!(links[0].body, "bold and italic");
+    }
+
+    // --- extract_imports tests ---
+
+    #[test]
+    fn test_extract_import_relative() {
+        let source = Source::detached(r#"#import "./utils.typ": *"#);
+        let imports = extract_imports(&source);
+
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].path, "./utils.typ");
+        assert!(!imports[0].is_package);
+    }
+
+    #[test]
+    fn test_extract_import_package() {
+        let source = Source::detached(r#"#import "@preview/tablex:0.0.6": tablex"#);
+        let imports = extract_imports(&source);
+
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].path, "@preview/tablex:0.0.6");
+        assert!(imports[0].is_package);
+    }
+
+    #[test]
+    fn test_extract_include() {
+        let source = Source::detached(r#"#include "./figures/fig1.typ""#);
+        let imports = extract_imports(&source);
+
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].path, "./figures/fig1.typ");
+        assert!(!imports[0].is_package);
+    }
+
+    #[test]
+    fn test_extract_multiple_imports() {
+        let source = Source::detached(
+            r#"
+            #import "./utils.typ": *
+            #import "@preview/tablex:0.0.6": tablex
+            #include "./figures/fig1.typ"
+        "#,
+        );
+        let imports = extract_imports(&source);
+
+        assert_eq!(imports.len(), 3);
+        assert_eq!(imports[0].path, "./utils.typ");
+        assert!(!imports[0].is_package);
+        assert_eq!(imports[1].path, "@preview/tablex:0.0.6");
+        assert!(imports[1].is_package);
+        assert_eq!(imports[2].path, "./figures/fig1.typ");
+        assert!(!imports[2].is_package);
+    }
+
+    #[test]
+    fn test_extract_import_byte_range() {
+        let source = Source::detached(r#"#import "./utils.typ": *"#);
+        let imports = extract_imports(&source);
+
+        assert_eq!(imports.len(), 1);
+        // byte_range should cover the Str node including quotes
+        let source_text = source.text();
+        let range_text = &source_text[imports[0].byte_range.clone()];
+        assert_eq!(range_text, "\"./utils.typ\"");
+    }
+
+    #[test]
+    fn test_no_imports() {
+        let source = Source::detached("Just plain text with no imports");
+        let imports = extract_imports(&source);
+
+        assert_eq!(imports.len(), 0);
     }
 }

--- a/crates/core/src/reticulate/parser.rs
+++ b/crates/core/src/reticulate/parser.rs
@@ -1,5 +1,7 @@
 use crate::reticulate::types::{ImportInfo, LinkInfo};
+use crate::reticulate::validator::is_relative_typ_link;
 use std::collections::HashMap;
+use std::ops::Range;
 use typst::syntax::{Source, SyntaxKind, SyntaxNode};
 
 /// The identifier in the Typst AST for links.
@@ -8,6 +10,11 @@ const LINK_IDENT_ID: &str = "link";
 /// Maps a wrapper function name to the index of its parameter that is passed
 /// as the URL to the inner `link()` call.
 pub type WrapperMap = HashMap<String, usize>;
+
+/// Maps a let-binding name to its constant `.typ` string value and the
+/// byte range of the `Str` node in the source. Only file-scope bindings
+/// of the form `#let x = "./something.typ"` are tracked.
+pub type UrlBindingMap = HashMap<String, (String, std::ops::Range<usize>)>;
 
 /// Extract all links from Typst source by parsing and traversing AST.
 ///
@@ -36,9 +43,17 @@ pub struct ExtractedNodes {
 pub fn extract_nodes(source: &Source) -> ExtractedNodes {
     let root = typst::syntax::parse(source.text());
     let wrappers = collect_link_wrappers(&root);
+    let url_bindings = collect_url_bindings(&root);
     let mut links = Vec::new();
     let mut imports = Vec::new();
-    extract_from_node(&root, &root, &mut links, &mut imports, &wrappers);
+    extract_from_node(
+        &root,
+        &root,
+        &mut links,
+        &mut imports,
+        &wrappers,
+        &url_bindings,
+    );
     ExtractedNodes { links, imports }
 }
 
@@ -49,10 +64,11 @@ fn extract_from_node(
     links: &mut Vec<LinkInfo>,
     imports: &mut Vec<ImportInfo>,
     wrappers: &WrapperMap,
+    url_bindings: &UrlBindingMap,
 ) {
     // Collect link info from function calls
     if node.kind() == SyntaxKind::FuncCall
-        && let Some(link_info) = parse_link_call(node, root, wrappers)
+        && let Some(link_info) = parse_link_call(node, root, wrappers, url_bindings)
     {
         links.push(link_info);
     }
@@ -66,7 +82,7 @@ fn extract_from_node(
 
     // Recursively traverse children
     for child in node.children() {
-        extract_from_node(child, root, links, imports, wrappers);
+        extract_from_node(child, root, links, imports, wrappers, url_bindings);
     }
 }
 
@@ -74,6 +90,7 @@ fn parse_link_call(
     node: &SyntaxNode,
     root: &SyntaxNode,
     wrappers: &WrapperMap,
+    url_bindings: &UrlBindingMap,
 ) -> Option<LinkInfo> {
     let ident = node.children().find(|n| n.kind() == SyntaxKind::Ident)?;
 
@@ -87,32 +104,40 @@ fn parse_link_call(
 
     let args = node.children().find(|n| n.kind() == SyntaxKind::Args)?;
 
-    if is_wrapper {
-        // Wrapper call: byte range covers only the Str argument
-        let (url, str_node) = extract_nth_string_arg_with_node(args, url_param_index)?;
-        let offset = calculate_node_offset(root, str_node)?;
-        let byte_range = offset..(offset + str_node.len());
-
+    // Try to extract a literal string arg first
+    if let Some((url, str_node)) = extract_nth_string_arg_with_node(args, url_param_index) {
+        if is_wrapper {
+            let offset = calculate_node_offset(root, str_node)?;
+            let byte_range = offset..(offset + str_node.len());
+            Some(LinkInfo {
+                url,
+                body: String::new(),
+                span: node.span(),
+                byte_range,
+                is_wrapper_call: true,
+            })
+        } else {
+            let body = extract_link_body(node)?;
+            let offset = calculate_node_offset(root, node)?;
+            let byte_range = offset..(offset + node.len());
+            Some(LinkInfo {
+                url,
+                body,
+                span: node.span(),
+                byte_range,
+                is_wrapper_call: false,
+            })
+        }
+    } else {
+        // No literal string — try to resolve a let-bound variable
+        let var_name = extract_nth_ident_arg(args, url_param_index)?;
+        let (url, str_byte_range) = url_bindings.get(var_name.as_str())?;
         Some(LinkInfo {
-            url,
+            url: url.clone(),
             body: String::new(),
             span: node.span(),
-            byte_range,
-            is_wrapper_call: true,
-        })
-    } else {
-        // Standard link() call: byte range covers the full expression
-        let url = extract_first_string_arg(args)?;
-        let body = extract_link_body(node)?;
-        let offset = calculate_node_offset(root, node)?;
-        let byte_range = offset..(offset + node.len());
-
-        Some(LinkInfo {
-            url,
-            body,
-            span: node.span(),
-            byte_range,
-            is_wrapper_call: false,
+            byte_range: str_byte_range.clone(),
+            is_wrapper_call: true, // reuse flag: rewrite via ReplaceStringLiteralInPlace
         })
     }
 }
@@ -139,6 +164,29 @@ fn extract_nth_string_arg_with_node(
                 return Some((text, child));
             }
             return None; // n-th positional arg is not a string
+        }
+        pos += 1;
+    }
+    None
+}
+
+/// Return the text of the n-th positional `Ident` argument.
+fn extract_nth_ident_arg(args: &SyntaxNode, n: usize) -> Option<String> {
+    let mut pos = 0;
+    for child in args.children() {
+        match child.kind() {
+            SyntaxKind::LeftParen
+            | SyntaxKind::RightParen
+            | SyntaxKind::Comma
+            | SyntaxKind::Space
+            | SyntaxKind::Named => continue,
+            _ => {}
+        }
+        if pos == n {
+            if child.kind() == SyntaxKind::Ident {
+                return Some(child.text().to_string());
+            }
+            return None;
         }
         pos += 1;
     }
@@ -318,6 +366,69 @@ fn find_link_call(node: &SyntaxNode) -> Option<&SyntaxNode> {
         }
     }
     None
+}
+
+// ---------------------------------------------------------------------------
+// Let-bound URL variable collection
+// ---------------------------------------------------------------------------
+
+/// Collect file-scope `#let x = "./something.typ"` bindings.
+///
+/// Only bindings where the value is a string literal containing a `.typ`
+/// path are tracked. Bindings inside closures or code blocks are skipped.
+pub fn collect_url_bindings(root: &SyntaxNode) -> UrlBindingMap {
+    let mut map = HashMap::new();
+    collect_url_bindings_from_node(root, root, &mut map, false);
+    map
+}
+
+fn collect_url_bindings_from_node(
+    node: &SyntaxNode,
+    root: &SyntaxNode,
+    map: &mut UrlBindingMap,
+    in_scope: bool,
+) {
+    // Only track file-scope bindings (not inside closures/code blocks)
+    if in_scope {
+        return;
+    }
+
+    if node.kind() == SyntaxKind::LetBinding {
+        let children: Vec<_> = node.children().collect();
+        // Find the binding name (first Ident) and the value (first Str after Eq)
+        let name = children.iter().find(|c| c.kind() == SyntaxKind::Ident);
+        let Some(name) = name else { return };
+        let binding_name = name.text().to_string();
+
+        // Look for a Str value — must be after the Eq token
+        let mut after_eq = false;
+        for child in &children {
+            if child.kind() == SyntaxKind::Eq {
+                after_eq = true;
+                continue;
+            }
+            if after_eq && child.kind() == SyntaxKind::Str {
+                let text = child.text().trim_matches('"').to_string();
+                if is_relative_typ_link(&text) {
+                    if let Some(offset) = calculate_node_offset(root, child) {
+                        let byte_range = offset..(offset + child.len());
+                        map.insert(binding_name, (text, byte_range));
+                    }
+                }
+                break;
+            }
+        }
+        return; // Don't recurse into LetBinding children
+    }
+
+    // Stop descending into closures and code blocks
+    if node.kind() == SyntaxKind::Closure || node.kind() == SyntaxKind::CodeBlock {
+        return;
+    }
+
+    for child in node.children() {
+        collect_url_bindings_from_node(child, root, map, in_scope);
+    }
 }
 
 /// Parse a ModuleImport or ModuleInclude node into ImportInfo.

--- a/crates/core/src/reticulate/parser.rs
+++ b/crates/core/src/reticulate/parser.rs
@@ -120,20 +120,14 @@ fn collect_unresolvable_link(
     results: &mut Vec<usize>,
 ) {
     // Only direct `#link(...)` calls, not unknown wrapper calls.
-    let Some(ident) = func_call
-        .children()
-        .find(|n| n.kind() == SyntaxKind::Ident)
-    else {
+    let Some(ident) = func_call.children().find(|n| n.kind() == SyntaxKind::Ident) else {
         return;
     };
     if ident.text() != LINK_IDENT_ID {
         return;
     }
 
-    let Some(args) = func_call
-        .children()
-        .find(|n| n.kind() == SyntaxKind::Args)
-    else {
+    let Some(args) = func_call.children().find(|n| n.kind() == SyntaxKind::Args) else {
         return;
     };
 

--- a/crates/core/src/reticulate/serializer.rs
+++ b/crates/core/src/reticulate/serializer.rs
@@ -54,6 +54,10 @@ pub fn apply_transformations(
                 // New:      #link(<label>)[body]
                 replace_url_in_link(original, new_label, true)
             }
+            LinkTransform::ReplaceStringLiteralInPlace { new_value } => {
+                // byte_range covers the Str node including surrounding quotes
+                format!("\"{}\"", new_value)
+            }
 
             LinkTransform::KeepOriginal => {
                 // No change

--- a/crates/core/src/reticulate/serializer.rs
+++ b/crates/core/src/reticulate/serializer.rs
@@ -77,9 +77,8 @@ pub fn apply_transformations(
 /// Returns byte ranges of all Raw nodes (code blocks and inline code).
 /// Links within these ranges should be preserved unchanged.
 pub fn find_code_block_ranges(source: &Source) -> Vec<Range<usize>> {
-    let root = typst::syntax::parse(source.text());
     let mut ranges = Vec::new();
-    collect_raw_ranges(&root, &mut ranges, 0);
+    collect_raw_ranges(source.root(), &mut ranges, 0);
     ranges
 }
 

--- a/crates/core/src/reticulate/serializer.rs
+++ b/crates/core/src/reticulate/serializer.rs
@@ -40,10 +40,13 @@ pub fn apply_transformations(
                 format!("[{}]", body)
             }
             LinkTransform::ReplaceUrl { new_url } => {
-                // Replace URL but keep the rest of the syntax
-                // Original: #link("old.typ")[body]
-                // New:      #link("new.typ")[body]
-                replace_url_in_link(original, new_url, false)
+                // Bare string literal (import/include): just re-quote
+                if original.starts_with('"') {
+                    format!("\"{}\"", new_url)
+                } else {
+                    // Full link expression: preserve surrounding syntax
+                    replace_url_in_link(original, new_url, false)
+                }
             }
             LinkTransform::ReplaceUrlWithLabel { new_label } => {
                 // Replace URL but keep the rest of the syntax

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -1,5 +1,6 @@
 use crate::pdf_utils::{DocumentTitle, sanitize_label_name};
 use crate::plugins::SpineOptions;
+use crate::reticulate::transformer::LinkTransformer;
 use crate::{Result, RheoError, TYP_EXT};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -46,6 +47,12 @@ impl BuiltSpine {
         // Merge when caller requests it (typically only PDF merged mode).
         // Other formats (epub, html) handle concatenation differently.
 
+        let transformer = if format_ext == "pdf" && spine_files.len() > 1 {
+            LinkTransformer::new(format_ext).with_spine(spine_files.to_vec())
+        } else {
+            LinkTransformer::new(format_ext)
+        };
+
         let mut sources = Vec::new();
 
         for spine_file in &spine_files {
@@ -57,11 +64,7 @@ impl BuiltSpine {
                 ))
             })?;
 
-            // TODO: this source needs to be transformed according to what the plugin specifies,
-            // i.e. whether relative linking makes sense. For PDF, it doesn't, whereas for HTML and
-            // EPUB, it does.
-            let transformed_source =
-                transform_source(&source, spine_file, &spine_files, format_ext, root)?;
+            let transformed_source = transformer.transform_source(&source, spine_file, root)?;
 
             let final_source = if merge {
                 let (label, doc_title) = extract_label_and_title(&source, spine_file)?;
@@ -90,29 +93,6 @@ impl BuiltSpine {
             source: final_sources,
         })
     }
-}
-
-/// Transform source using AST-based link transformation.
-fn transform_source(
-    source: &str,
-    spine_file: &Path,
-    spine_files: &[PathBuf],
-    ext_name: &str,
-    project_root: &Path,
-) -> Result<String> {
-    use crate::reticulate::transformer::LinkTransformer;
-
-    // Plugins that produce a single merged PDF are a special case, as here we want to use Typst's
-    // internal link resolution to resolve Rheo links
-    let transformer = if ext_name == "pdf" && spine_files.len() > 1 {
-        // Merged PDF: pass spine for label references
-        LinkTransformer::new(ext_name).with_spine(spine_files.to_vec())
-    } else {
-        // All other formats
-        LinkTransformer::new(ext_name)
-    };
-
-    transformer.transform_source(source, spine_file, project_root)
 }
 
 fn extract_label_and_title(source: &str, spine_file: &Path) -> Result<(String, String)> {

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -222,37 +222,9 @@ pub fn generate_spine(
             "spine configuration required but not provided",
         ));
     }
-
     match spine_config {
         None => collect_one_typst_file(root),
-        Some(spine) if spine.vertebrae.is_empty() => collect_all_typst_files(root),
-        Some(spine) => {
-            let mut typst_files = Vec::new();
-            for pattern in &spine.vertebrae {
-                let glob_pattern = root.join(pattern).display().to_string();
-                let glob = glob::glob(&glob_pattern).map_err(|e| {
-                    RheoError::project_config(format!("invalid glob pattern '{}': {}", pattern, e))
-                })?;
-
-                let mut glob_files: Vec<PathBuf> = glob
-                    .filter_map(|entry| entry.ok())
-                    .filter(|path| path.is_file())
-                    .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("typ"))
-                    .collect();
-
-                // Sort by full path (lexicographic) for consistent ordering
-                glob_files.sort();
-                typst_files.extend(glob_files);
-            }
-
-            if typst_files.is_empty() {
-                return Err(RheoError::project_config(
-                    "merge spine matched no .typ files",
-                ));
-            }
-
-            Ok(typst_files)
-        }
+        Some(spine) => spine.generate(root),
     }
 }
 

--- a/crates/core/src/reticulate/transformer.rs
+++ b/crates/core/src/reticulate/transformer.rs
@@ -33,6 +33,9 @@ impl LinkTransformer {
     /// Transform source code by processing all links and rewriting relative
     /// import/include paths so they resolve correctly from the project root
     /// (needed when spine files are merged into a temp file at the root).
+    ///
+    /// Parses the source exactly once and traverses the AST once to collect
+    /// both link info and import info.
     pub fn transform_source(
         &self,
         source: &str,
@@ -42,12 +45,11 @@ impl LinkTransformer {
         use crate::reticulate::{parser, serializer};
 
         let source_obj = typst::syntax::Source::detached(source);
-        let links = parser::extract_links(&source_obj);
-        let mut transformations = self.compute_transformations(&links, current_file)?;
+        let extracted = parser::extract_nodes(&source_obj);
+        let mut transformations = self.compute_transformations(&extracted.links, current_file)?;
 
         // Rewrite relative import/include paths to be project-root-relative
-        let imports = parser::extract_imports(&source_obj);
-        for import in &imports {
+        for import in &extracted.imports {
             if import.is_package || import.path.starts_with('/') {
                 continue;
             }

--- a/crates/core/src/reticulate/transformer.rs
+++ b/crates/core/src/reticulate/transformer.rs
@@ -126,11 +126,9 @@ impl LinkTransformer {
             // ReplaceStringLiteralInPlace regardless of the computed transform.
             let transform = if link.is_wrapper_call {
                 match transform {
-                    LinkTransform::Remove { .. } => {
-                        LinkTransform::ReplaceStringLiteralInPlace {
-                            new_value: String::new(),
-                        }
-                    }
+                    LinkTransform::Remove { .. } => LinkTransform::ReplaceStringLiteralInPlace {
+                        new_value: String::new(),
+                    },
                     LinkTransform::ReplaceUrl { new_url } => {
                         LinkTransform::ReplaceStringLiteralInPlace { new_value: new_url }
                     }

--- a/crates/core/src/reticulate/transformer.rs
+++ b/crates/core/src/reticulate/transformer.rs
@@ -120,6 +120,29 @@ impl LinkTransformer {
                 LinkTransform::KeepOriginal
             };
 
+            // Wrapper-call links only cover the Str argument, so use
+            // ReplaceStringLiteralInPlace regardless of the computed transform.
+            let transform = if link.is_wrapper_call {
+                match transform {
+                    LinkTransform::Remove { .. } => {
+                        LinkTransform::ReplaceStringLiteralInPlace {
+                            new_value: String::new(),
+                        }
+                    }
+                    LinkTransform::ReplaceUrl { new_url } => {
+                        LinkTransform::ReplaceStringLiteralInPlace { new_value: new_url }
+                    }
+                    LinkTransform::ReplaceUrlWithLabel { new_label } => {
+                        LinkTransform::ReplaceStringLiteralInPlace {
+                            new_value: new_label,
+                        }
+                    }
+                    other => other,
+                }
+            } else {
+                transform
+            };
+
             transformations.push((link.byte_range.clone(), transform));
         }
 
@@ -159,6 +182,7 @@ mod tests {
             body: body.to_string(),
             span: Span::detached(),
             byte_range,
+            is_wrapper_call: false,
         }
     }
 

--- a/crates/core/src/reticulate/transformer.rs
+++ b/crates/core/src/reticulate/transformer.rs
@@ -30,18 +30,39 @@ impl LinkTransformer {
         self
     }
 
-    /// Transform source code by processing all links.
+    /// Transform source code by processing all links and rewriting relative
+    /// import/include paths so they resolve correctly from the project root
+    /// (needed when spine files are merged into a temp file at the root).
     pub fn transform_source(
         &self,
         source: &str,
         current_file: &Path,
-        _project_root: &Path,
+        project_root: &Path,
     ) -> Result<String> {
         use crate::reticulate::{parser, serializer};
 
         let source_obj = typst::syntax::Source::detached(source);
         let links = parser::extract_links(&source_obj);
-        let transformations = self.compute_transformations(&links, current_file)?;
+        let mut transformations = self.compute_transformations(&links, current_file)?;
+
+        // Rewrite relative import/include paths to be project-root-relative
+        let imports = parser::extract_imports(&source_obj);
+        for import in &imports {
+            if import.is_package || import.path.starts_with('/') {
+                continue;
+            }
+            let file_dir = current_file.parent().unwrap_or(Path::new(""));
+            let absolute = file_dir.join(&import.path);
+            let new_path = absolute
+                .strip_prefix(project_root)
+                .map(|p| p.to_str().unwrap().to_owned())
+                .unwrap_or_else(|_| import.path.clone());
+            transformations.push((
+                import.byte_range.clone(),
+                LinkTransform::ReplaceUrl { new_url: new_path },
+            ));
+        }
+
         let code_ranges = serializer::find_code_block_ranges(&source_obj);
         Ok(serializer::apply_transformations(
             source,

--- a/crates/core/src/reticulate/transformer.rs
+++ b/crates/core/src/reticulate/transformer.rs
@@ -6,6 +6,7 @@ use crate::{Result, RheoError};
 use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+use tracing::warn;
 
 /// Link transformer that converts Typst links to format-specific targets.
 pub struct LinkTransformer {
@@ -46,6 +47,18 @@ impl LinkTransformer {
 
         let source_obj = typst::syntax::Source::detached(source);
         let extracted = parser::extract_nodes(&source_obj);
+
+        for line in &extracted.unresolvable_link_lines {
+            warn!(
+                file = %current_file.display(),
+                line = line,
+                "rheo: #link() call has a non-literal URL argument that cannot be statically \
+                 transformed. The .typ extension will NOT be rewritten in the output. \
+                 To fix: use a string literal directly: #link(\"./file.typ\")[...], \
+                 or define the wrapper function in the same file."
+            );
+        }
+
         let mut transformations = self.compute_transformations(&extracted.links, current_file)?;
 
         // Rewrite relative import/include paths to be project-root-relative
@@ -291,5 +304,28 @@ mod tests {
         assert_eq!(extract_filename("../parent/file.typ"), "file.typ");
         assert_eq!(extract_filename("/absolute/path.typ"), "path.typ");
         assert_eq!(extract_filename("simple.typ"), "simple.typ");
+    }
+
+    #[test]
+    fn test_unresolvable_link_does_not_error() {
+        let source = r#"#link(compute_url())[text]"#;
+        let transformer = LinkTransformer::new("html");
+        let result =
+            transformer.transform_source(source, Path::new("test.typ"), Path::new("/root"));
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains("#link(compute_url())"));
+    }
+
+    #[test]
+    fn test_unresolvable_link_passes_through_unchanged() {
+        // Dynamic URL expression: should compile fine and leave link untouched
+        let source = r#"#link("./ch" + num + ".typ")[Chapter]"#;
+        let transformer = LinkTransformer::new("html");
+        let result =
+            transformer.transform_source(source, Path::new("test.typ"), Path::new("/root"));
+        assert!(result.is_ok());
+        // The link call passes through unchanged (no transformation applied)
+        let output = result.unwrap();
+        assert!(output.contains("#link("));
     }
 }

--- a/crates/core/src/reticulate/types.rs
+++ b/crates/core/src/reticulate/types.rs
@@ -17,6 +17,19 @@ pub struct LinkInfo {
     pub byte_range: Range<usize>,
 }
 
+/// Information about an import/include extracted from the AST
+#[derive(Debug, Clone)]
+pub struct ImportInfo {
+    /// The raw path string (e.g. "./utils.typ" or "@preview/foo:0.1.0")
+    pub path: String,
+
+    /// Byte range of the path string (NOT the whole statement)
+    pub byte_range: Range<usize>,
+
+    /// true if path starts with '@' (package import)
+    pub is_package: bool,
+}
+
 /// Link transformation operation
 #[derive(Debug, Clone)]
 pub enum LinkTransform {

--- a/crates/core/src/reticulate/types.rs
+++ b/crates/core/src/reticulate/types.rs
@@ -15,6 +15,11 @@ pub struct LinkInfo {
 
     /// Byte range in the source text
     pub byte_range: Range<usize>,
+
+    /// True when this link was extracted via a same-file wrapper function
+    /// (e.g. `#let f(x) = link(x)`).  Wrapper-call byte ranges cover only
+    /// the `Str` argument, not the full function call.
+    pub is_wrapper_call: bool,
 }
 
 /// Information about an import/include extracted from the AST
@@ -44,4 +49,9 @@ pub enum LinkTransform {
 
     /// Keep original (no transformation)
     KeepOriginal,
+
+    /// Replace only the quoted string literal at `byte_range` with `new_value`
+    /// (re-quoted).  Used for wrapper-function call sites where only the URL
+    /// argument should change, not the surrounding call syntax.
+    ReplaceStringLiteralInPlace { new_value: String },
 }

--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -110,8 +110,13 @@ impl RheoWorld {
         self.slots.lock().clear();
     }
 
-    /// Change the main file for this world.
+    /// Change the main file for this world, invalidating only main-file-dependent slots.
+    ///
+    /// Only the outgoing and incoming main file slots are invalidated. All other slots
+    /// (shared imports, packages) are deterministic given `format_name` and `root`, so
+    /// they remain valid across per-file compilations.
     pub fn set_main(&mut self, main_file: &Path) -> Result<()> {
+        let old_main = self.main;
         let main_path = crate::path_utils::canonicalize_path(main_file)?;
 
         let main_vpath = VirtualPath::within_root(&main_path, &self.root).ok_or_else(|| {
@@ -119,6 +124,11 @@ impl RheoWorld {
         })?;
 
         self.main = FileId::new(None, main_vpath);
+
+        let mut slots = self.slots.lock();
+        slots.remove(&old_main);
+        slots.remove(&self.main);
+
         Ok(())
     }
 

--- a/crates/tests/ref/examples/merged-imports/pdf/merged-imports.metadata.json
+++ b/crates/tests/ref/examples/merged-imports/pdf/merged-imports.metadata.json
@@ -1,0 +1,5 @@
+{
+  "filetype": "pdf",
+  "file_size": 2842,
+  "page_count": 1
+}

--- a/crates/tests/store/compat/merged-imports/content/chapters/ch01.typ
+++ b/crates/tests/store/compat/merged-imports/content/chapters/ch01.typ
@@ -1,0 +1,7 @@
+#import "../shared/macros.typ": greeting
+
+= Chapter One
+
+#greeting("Reader")
+
+This is chapter one.

--- a/crates/tests/store/compat/merged-imports/content/chapters/ch02.typ
+++ b/crates/tests/store/compat/merged-imports/content/chapters/ch02.typ
@@ -1,0 +1,5 @@
+#include "../shared/helpers.typ"
+
+= Chapter Two
+
+This is chapter two.

--- a/crates/tests/store/compat/merged-imports/content/shared/helpers.typ
+++ b/crates/tests/store/compat/merged-imports/content/shared/helpers.typ
@@ -1,0 +1,2 @@
+// Shared helper functions
+#let greeting(name) = [*Hi, #name!*]

--- a/crates/tests/store/compat/merged-imports/content/shared/macros.typ
+++ b/crates/tests/store/compat/merged-imports/content/shared/macros.typ
@@ -1,0 +1,4 @@
+// Shared macros
+#let emph-box(body) = rect(fill: blue.darken(10%), text(body))
+
+#let greeting(name) = [*Hi, #name!*]

--- a/crates/tests/store/compat/merged-imports/rheo.toml
+++ b/crates/tests/store/compat/merged-imports/rheo.toml
@@ -1,0 +1,13 @@
+version = "0.2.0"
+
+content_dir = "content"
+build_dir = "build"
+formats = ["pdf"]
+
+[pdf.spine]
+title = "Merged Imports"
+vertebrae = [
+  "chapters/ch01.typ",
+  "chapters/ch02.typ"
+]
+merge = true

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -39,6 +39,7 @@ use std::path::PathBuf;
 #[test_case("cases/error_formatting/invalid_field.typ")]
 #[test_case("cases/error_formatting/multiple_errors.typ")]
 #[test_case("cases/error_formatting/array_index_error.typ")]
+#[test_case("store/compat/merged-imports")]
 fn run_test_case(name: &str) {
     let test_case = TestCase::new(name);
     let update_mode = env::var("UPDATE_REFERENCES").is_ok();
@@ -907,5 +908,68 @@ fn test_asset_path_override_subdirectory() {
     assert!(
         html.contains(r#"href="styles/custom.css""#),
         "HTML should contain link to styles/custom.css"
+    );
+}
+
+/// Test that a merged spine with a missing relative import produces a clear error
+/// referencing the original source file path (not a temp path).
+#[test]
+fn test_merged_imports_missing_file() {
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let project_path = dir.path();
+    let content_dir = project_path.join("content");
+    std::fs::create_dir_all(&content_dir).expect("Failed to create content dir");
+
+    std::fs::write(
+        project_path.join("rheo.toml"),
+        concat!(
+            "version = \"0.2.0\"\n",
+            "formats = [\"pdf\"]\n",
+            "\n",
+            "[pdf.spine]\n",
+            "title = \"Missing Import Test\"\n",
+            "vertebrae = [\"content/chapter.typ\"]\n",
+            "merge = true\n",
+        ),
+    )
+    .expect("Failed to write rheo.toml");
+
+    // chapter.typ imports a file that does not exist
+    std::fs::write(
+        content_dir.join("chapter.typ"),
+        "#import \"../shared/nonexistent.typ\": *\n\n= Chapter\n\nContent.\n",
+    )
+    .expect("Failed to write chapter.typ");
+
+    let build_dir = project_path.join("build");
+
+    let output = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "rheo",
+            "--",
+            "compile",
+            project_path.to_str().unwrap(),
+            "--pdf",
+            "--build-dir",
+            build_dir.to_str().unwrap(),
+        ])
+        .env("TYPST_IGNORE_SYSTEM_FONTS", "1")
+        .output()
+        .expect("Failed to run rheo compile");
+
+    assert!(
+        !output.status.success(),
+        "Expected compilation to fail when import target is missing"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The error should mention the source file name, not a temp/internal path
+    assert!(
+        stderr.contains("chapter.typ") || stderr.contains("nonexistent.typ"),
+        "Expected error to reference source file, got:\n{}",
+        stderr
     );
 }


### PR DESCRIPTION
When `merge = true`, Rheo generates a temporary Typst source document in the Rheo project directory. This breaks relative import paths for Typst files that are not at the base of the Rheo project directory, as when we try to compile the temporary document (to produce a single, merged output), the imports cannot resolve.

Here we rewrite the imports appropriately when generating the temporary Typst file. I have also attempted to fix some sharp edges of the relative link transformation (such as URLs to Typst source files not being transformed correctly unless they are directly in a `#link` call), and have tried to minimize the number of times we need to parse the Typst source for performance gains.