### PR TITLE
Allows multiple asset blocks for each format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ css_stylesheet = "custom.css"   # optional; path override for AssetConfig name
 [[html.assets]]
 css_stylesheet = "one.css"
 js_scripts     = "one.js"
+dest           = "subdir"  # optional; output subdirectory for this block's files
 
 [[html.assets]]
 css_stylesheet = "two.css"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,18 @@ copy = ["*.txt"]         # optional; glob patterns copied to every plugin output
 copy = ["images/**"]     # optional; glob patterns copied to html output dir only
 css_stylesheet = "custom.css"   # optional; path override for AssetConfig name
 
+# Multiple asset blocks: each [[html.assets]] contributes its own
+# overrides and copy patterns. All sources are copied verbatim by default.
+[[html.assets]]
+css_stylesheet = "one.css"
+js_scripts     = "one.js"
+
+[[html.assets]]
+css_stylesheet = "two.css"
+js_scripts     = "two.js"
+
+Plugins may declare a custom `AssetCombine` strategy on any `AssetConfig` (see `crates/core/src/plugins/mod.rs`) to bundle multiple sources into a single output.
+
 [pdf.spine]
 title = "My Book"
 vertebrae = ["cover.typ", "chapters/**/*.typ"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,12 @@
 **rheo** compiles Typst documents to PDF, HTML, and EPUB. Written in Rust using the Typst compiler as a library.
 
 **Source structure:**
-- `src/rs/` — Rust: `main.rs`, `cli.rs`, `compile.rs`, `world.rs`, `project.rs`, `output.rs`, `assets.rs`
+- `crates/cli/` — CLI entry point, `resolve_assets`, compilation orchestration
+- `crates/core/` — Config, plugin trait (`FormatPlugin`), `PluginContext`, `AssetConfig`, world, spine, compilation
+- `crates/html/` — HTML plugin (dev server, CSS/JS injection)
+- `crates/pdf/` — PDF plugin
+- `crates/epub/` — EPUB plugin
+- `crates/tests/` — Integration tests and harness
 - `src/typ/rheo.typ` — Core Typst template (auto-injected)
 - `build/` — Output dir (gitignored): `pdf/`, `html/`, `epub/`
 
@@ -29,7 +34,7 @@ cargo fmt && cargo clippy -- -D warnings
 ## rheo.toml
 
 ```toml
-version = "0.2.0"        # required, must match CLI version
+version = "0.2.1"        # required, must match CLI version
 content_dir = "content"  # optional
 build_dir = "build"      # optional
 formats = ["html", "pdf", "epub"]  # default formats
@@ -49,8 +54,6 @@ js_scripts     = "one.js"
 [[html.assets]]
 css_stylesheet = "two.css"
 js_scripts     = "two.js"
-
-Plugins may declare a custom `AssetCombine` strategy on any `AssetConfig` (see `crates/core/src/plugins/mod.rs`) to bundle multiple sources into a single output.
 
 [pdf.spine]
 title = "My Book"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1041,6 +1041,7 @@ mod tests {
                 name: "css_stylesheet",
                 default_path: "style.css",
                 required: false,
+                combine: None,
             }],
         };
         let section = PluginSection::default();
@@ -1067,6 +1068,7 @@ mod tests {
                 name: "css_stylesheet",
                 default_path: "style.css",
                 required: false,
+                combine: None,
             }],
         };
         let mut asset_extra = toml::map::Map::new();
@@ -1102,6 +1104,7 @@ mod tests {
                 name: "missing_asset",
                 default_path: "nonexistent.css",
                 required: true,
+                combine: None,
             }],
         };
         let section = PluginSection::default();
@@ -1128,6 +1131,7 @@ mod tests {
                 name: "optional_asset",
                 default_path: "nonexistent.css",
                 required: false,
+                combine: None,
             }],
         };
         let section = PluginSection::default();
@@ -1156,6 +1160,7 @@ mod tests {
                 name: "css_stylesheet",
                 default_path: "style.css",
                 required: false,
+                combine: None,
             }],
         };
         let mut asset_extra = toml::map::Map::new();

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -562,13 +562,8 @@ fn perform_compilation(
             &plugin_output_dir,
         )?;
 
-        // Execute copy patterns (global + per-plugin)
-        for pattern in project.config.copy.iter().chain(
-            plugin_section
-                .asset_blocks()
-                .iter()
-                .flat_map(|b| b.copy.iter()),
-        ) {
+        // Execute copy patterns — global (Pass A) then per-block (Pass B)
+        for pattern in project.config.copy.iter() {
             let abs_pattern = project.root.join(pattern).display().to_string();
             let entries = glob::glob(&abs_pattern).map_err(|e| {
                 RheoError::project_config(format!("invalid copy pattern '{}': {}", pattern, e))
@@ -595,6 +590,45 @@ fn perform_compilation(
             }
             if !matched {
                 debug!(pattern = %pattern, "copy pattern matched no files");
+            }
+        }
+
+        for block in plugin_section.asset_blocks() {
+            let block_dest = block.dest.as_deref();
+            for pattern in block.copy.iter() {
+                let abs_pattern = project.root.join(pattern).display().to_string();
+                let entries = glob::glob(&abs_pattern).map_err(|e| {
+                    RheoError::project_config(format!(
+                        "invalid copy pattern '{}': {}",
+                        pattern, e
+                    ))
+                })?;
+                let mut matched = false;
+                for entry in entries.filter_map(|e| e.ok()).filter(|p| p.is_file()) {
+                    matched = true;
+                    let rel = entry.strip_prefix(&project.root).unwrap_or(entry.as_path());
+                    let dest = match block_dest {
+                        Some(d) => plugin_output_dir.join(d).join(rel),
+                        None => plugin_output_dir.join(rel),
+                    };
+                    if let Some(parent) = dest.parent() {
+                        std::fs::create_dir_all(parent).map_err(|e| {
+                            RheoError::io(
+                                e,
+                                format!("creating directory for copy of {}", rel.display()),
+                            )
+                        })?;
+                    }
+                    std::fs::copy(&entry, &dest).map_err(|e| RheoError::AssetCopy {
+                        source: entry.clone(),
+                        dest: dest.clone(),
+                        error: e,
+                    })?;
+                    debug!(src = %entry.display(), dest = %dest.display(), "copied file");
+                }
+                if !matched {
+                    debug!(pattern = %pattern, "copy pattern matched no files");
+                }
             }
         }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -369,11 +369,39 @@ fn compile_one_file(
     Ok(())
 }
 
-/// Resolve plugin assets, applying path overrides from config.
-///
-/// For each declared asset, checks if the user configured a custom path
-/// via `plugin_section.extra[asset_name]`. If not, falls back to
-/// `asset_config.default_path`. Copies resolved files to the output directory.
+/// Default combiner used when AssetConfig.combine is None: copies each source
+/// verbatim into the build dir, preserving its path relative to the project root.
+fn default_copy_each(
+    sources: &[PathBuf],
+    project_root: &Path,
+    build_dir: &Path,
+) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::with_capacity(sources.len());
+    for src in sources {
+        let rel = src
+            .strip_prefix(project_root)
+            .expect("source is always project_root-joined");
+        let dest = build_dir.join(rel);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                RheoError::io(
+                    e,
+                    format!("creating directory for asset '{}'", rel.display()),
+                )
+            })?;
+        }
+        std::fs::copy(src, &dest).map_err(|e| RheoError::AssetCopy {
+            source: src.clone(),
+            dest: dest.clone(),
+            error: e,
+        })?;
+        out.push(dest);
+    }
+    Ok(out)
+}
+
+/// Resolve plugin assets, collecting overrides across all [[plugin.assets]] blocks
+/// and dispatching to the declared combine strategy.
 fn resolve_assets(
     plugin: &dyn FormatPlugin,
     plugin_section: &PluginSection,
@@ -382,42 +410,67 @@ fn resolve_assets(
 ) -> Result<HashMap<&'static str, Vec<Asset>>> {
     let mut resolved = HashMap::new();
     for asset_config in plugin.assets() {
-        let effective_path: &str = plugin_section
-            .get_string(asset_config.name)
-            .unwrap_or(asset_config.default_path);
+        let overrides: Vec<&str> = plugin_section.get_strings(asset_config.name);
+        let effective: Vec<&str> = if overrides.is_empty() {
+            vec![asset_config.default_path]
+        } else {
+            overrides
+        };
 
-        let src = project_root.join(effective_path);
-        if src.is_file() {
-            let dest = plugin_output_dir.join(effective_path);
-            if let Some(parent) = dest.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| {
-                    RheoError::io(
-                        e,
-                        format!("creating directory for asset '{}'", effective_path),
-                    )
-                })?;
+        let mut sources: Vec<PathBuf> = Vec::new();
+        let mut missing: Vec<&str> = Vec::new();
+        for path in &effective {
+            let abs = project_root.join(path);
+            if abs.is_file() {
+                sources.push(abs);
+            } else {
+                missing.push(path);
             }
-            std::fs::copy(&src, &dest).map_err(|e| RheoError::AssetCopy {
-                source: src.clone(),
-                dest: dest.clone(),
-                error: e,
-            })?;
-            resolved.insert(
-                asset_config.name,
-                vec![Asset {
-                    config: asset_config.clone(),
-                    resolved_path: dest,
-                    built_relative_path: effective_path.to_string(),
-                }],
-            );
-        } else if asset_config.required {
-            return Err(RheoError::project_config(format!(
-                "plugin '{}' requires input '{}' at '{}' but it was not found",
-                plugin.name(),
-                asset_config.name,
-                effective_path
-            )));
         }
+
+        if sources.is_empty() {
+            if asset_config.required {
+                return Err(RheoError::project_config(format!(
+                    "plugin '{}' requires input '{}' but no source was found (tried: {})",
+                    plugin.name(),
+                    asset_config.name,
+                    effective.join(", ")
+                )));
+            }
+            continue;
+        }
+
+        for m in &missing {
+            warn!(
+                plugin = plugin.name(),
+                asset = asset_config.name,
+                path = %m,
+                "asset override path not found, skipping"
+            );
+        }
+
+        let outputs: Vec<PathBuf> = match asset_config.combine {
+            Some(c) => c.combine(&sources, plugin_output_dir)?,
+            None => default_copy_each(&sources, project_root, plugin_output_dir)?,
+        };
+
+        let assets: Vec<Asset> = outputs
+            .into_iter()
+            .map(|abs| {
+                let rel = abs
+                    .strip_prefix(plugin_output_dir)
+                    .unwrap_or(&abs)
+                    .to_string_lossy()
+                    .into_owned();
+                Asset {
+                    config: asset_config.clone(),
+                    resolved_path: abs,
+                    built_relative_path: rel,
+                }
+            })
+            .collect();
+
+        resolved.insert(asset_config.name, assets);
     }
     Ok(resolved)
 }
@@ -940,7 +993,7 @@ fn run_clean(sub: &ArgMatches) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rheo_core::AssetConfig;
+    use rheo_core::{AssetCombine, AssetConfig};
     use rheo_core::config::{AssetsField, PluginAssets};
 
     #[test]
@@ -1183,5 +1236,170 @@ mod tests {
             output_dir.join("styles/custom.css").exists(),
             "subdirectory asset should be copied to output"
         );
+    }
+
+    #[test]
+    fn test_resolve_assets_multiple_blocks_default_copy_each() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        std::fs::write(project_root.join("one.css"), "/* one */").unwrap();
+        std::fs::write(project_root.join("two.css"), "/* two */").unwrap();
+
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "css_stylesheet",
+                default_path: "style.css",
+                required: false,
+                combine: None,
+            }],
+        };
+
+        let mut extra1 = toml::map::Map::new();
+        extra1.insert("css_stylesheet".into(), toml::Value::String("one.css".into()));
+        let mut extra2 = toml::map::Map::new();
+        extra2.insert("css_stylesheet".into(), toml::Value::String("two.css".into()));
+        let section = PluginSection {
+            assets: Some(AssetsField::Multiple(vec![
+                PluginAssets { extra: extra1, ..Default::default() },
+                PluginAssets { extra: extra2, ..Default::default() },
+            ])),
+            ..Default::default()
+        };
+
+        let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
+        let assets = resolved.get("css_stylesheet").unwrap();
+        assert_eq!(assets.len(), 2);
+        assert!(output_dir.join("one.css").exists());
+        assert!(output_dir.join("two.css").exists());
+    }
+
+    struct MockConcat;
+
+    impl AssetCombine for MockConcat {
+        fn combine(
+            &self,
+            sources: &[PathBuf],
+            build_dir: &Path,
+        ) -> rheo_core::Result<Vec<PathBuf>> {
+            let mut content = String::new();
+            for s in sources {
+                content.push_str(&std::fs::read_to_string(s).unwrap());
+            }
+            let dest = build_dir.join("combined.css");
+            std::fs::write(&dest, &content)
+                .map_err(|e| rheo_core::RheoError::io(e, "writing combined asset"))?;
+            Ok(vec![dest])
+        }
+    }
+
+    #[test]
+    fn test_resolve_assets_invokes_custom_combiner() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        std::fs::write(project_root.join("a.css"), "/* a */").unwrap();
+        std::fs::write(project_root.join("b.css"), "/* b */").unwrap();
+
+        static COMBINER: MockConcat = MockConcat;
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "css_stylesheet",
+                default_path: "style.css",
+                required: false,
+                combine: Some(&COMBINER),
+            }],
+        };
+
+        let mut extra1 = toml::map::Map::new();
+        extra1.insert("css_stylesheet".into(), toml::Value::String("a.css".into()));
+        let mut extra2 = toml::map::Map::new();
+        extra2.insert("css_stylesheet".into(), toml::Value::String("b.css".into()));
+        let section = PluginSection {
+            assets: Some(AssetsField::Multiple(vec![
+                PluginAssets { extra: extra1, ..Default::default() },
+                PluginAssets { extra: extra2, ..Default::default() },
+            ])),
+            ..Default::default()
+        };
+
+        let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
+        let assets = resolved.get("css_stylesheet").unwrap();
+        assert_eq!(assets.len(), 1);
+        assert!(output_dir.join("combined.css").exists());
+        assert_eq!(
+            std::fs::read_to_string(output_dir.join("combined.css")).unwrap(),
+            "/* a *//* b */"
+        );
+    }
+
+    #[test]
+    fn test_resolve_assets_required_all_missing_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "missing_asset",
+                default_path: "nonexistent.css",
+                required: true,
+                combine: None,
+            }],
+        };
+        let section = PluginSection::default();
+
+        let result = resolve_assets(&plugin, &section, project_root, &output_dir);
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("requires input"),
+            "expected 'requires input' in error, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_resolve_assets_required_some_missing_warns_but_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        std::fs::write(project_root.join("exists.css"), "body {}").unwrap();
+
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "css_stylesheet",
+                default_path: "style.css",
+                required: true,
+                combine: None,
+            }],
+        };
+
+        let mut extra1 = toml::map::Map::new();
+        extra1.insert("css_stylesheet".into(), toml::Value::String("exists.css".into()));
+        let mut extra2 = toml::map::Map::new();
+        extra2.insert("css_stylesheet".into(), toml::Value::String("missing.css".into()));
+        let section = PluginSection {
+            assets: Some(AssetsField::Multiple(vec![
+                PluginAssets { extra: extra1, ..Default::default() },
+                PluginAssets { extra: extra2, ..Default::default() },
+            ])),
+            ..Default::default()
+        };
+
+        let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
+        let assets = resolved.get("css_stylesheet").unwrap();
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0].built_relative_path, "exists.css");
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -373,9 +373,12 @@ fn compile_one_file(
 fn copy_each(sources: &[PathBuf], project_root: &Path, build_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut out = Vec::with_capacity(sources.len());
     for src in sources {
-        let rel = src
-            .strip_prefix(project_root)
-            .expect("source is always project_root-joined");
+        let rel = src.strip_prefix(project_root).map_err(|_| {
+            RheoError::project_config(format!(
+                "asset override path '{}' is absolute or outside the project root; paths must be relative to the project root",
+                src.display()
+            ))
+        })?;
         let dest = build_dir.join(rel);
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
@@ -396,7 +399,7 @@ fn copy_each(sources: &[PathBuf], project_root: &Path, build_dir: &Path) -> Resu
 }
 
 /// Resolve plugin assets, collecting overrides across all [[plugin.assets]] blocks
-/// and dispatching to the declared combine strategy.
+/// and copying each source verbatim into the plugin output dir.
 fn resolve_assets(
     plugin: &dyn FormatPlugin,
     plugin_section: &PluginSection,
@@ -404,6 +407,7 @@ fn resolve_assets(
     plugin_output_dir: &Path,
 ) -> Result<HashMap<&'static str, Vec<Asset>>> {
     let mut resolved = HashMap::new();
+    let mut seen_relative_paths: HashMap<String, PathBuf> = HashMap::new();
     for asset_config in plugin.assets() {
         let overrides: Vec<&str> = plugin_section.get_strings(asset_config.name);
         let effective: Vec<&str> = if overrides.is_empty() {
@@ -451,16 +455,25 @@ fn resolve_assets(
             .map(|abs| {
                 let rel = abs
                     .strip_prefix(plugin_output_dir)
-                    .unwrap_or(&abs)
+                    .expect("copy_each output is always under plugin_output_dir")
                     .to_string_lossy()
                     .into_owned();
-                Asset {
+                if let Some(prev) = seen_relative_paths.get(&rel) {
+                    return Err(RheoError::project_config(format!(
+                        "asset path collision: '{}' produced by both '{}' and '{}'",
+                        rel,
+                        prev.display(),
+                        abs.display()
+                    )));
+                }
+                seen_relative_paths.insert(rel.clone(), abs.clone());
+                Ok(Asset {
                     config: asset_config.clone(),
                     resolved_path: abs,
                     built_relative_path: rel,
-                }
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         resolved.insert(asset_config.name, assets);
     }
@@ -1347,5 +1360,113 @@ mod tests {
         let assets = resolved.get("css_stylesheet").unwrap();
         assert_eq!(assets.len(), 1);
         assert_eq!(assets[0].built_relative_path, "exists.css");
+    }
+
+    #[test]
+    fn test_resolve_assets_collision_across_blocks_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        // Both blocks point at the same file via different paths isn't a collision,
+        // but two blocks with the same *relative* dest path is. Create two files
+        // in different dirs that both strip to "style.css" in the output dir.
+        std::fs::write(project_root.join("a.css"), "/* a */").unwrap();
+        std::fs::write(project_root.join("b.css"), "/* b */").unwrap();
+
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "css_stylesheet",
+                default_path: "style.css",
+                required: false,
+            }],
+        };
+
+        // Both overrides resolve to the same built_relative_path "style.css"
+        // because they're at the project root. This means copy_each would
+        // overwrite — detect this as a collision.
+        // Actually, both "a.css" and "b.css" are at the root, so their dest
+        // paths differ ("a.css" vs "b.css"). To create a real collision we
+        // need two blocks that both set css_stylesheet = "same.css".
+        std::fs::write(project_root.join("same.css"), "/* same */").unwrap();
+
+        let mut extra1 = toml::map::Map::new();
+        extra1.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("same.css".into()),
+        );
+        let mut extra2 = toml::map::Map::new();
+        extra2.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("same.css".into()),
+        );
+        let section = PluginSection {
+            assets: Some(AssetsField::Multiple(vec![
+                PluginAssets {
+                    extra: extra1,
+                    ..Default::default()
+                },
+                PluginAssets {
+                    extra: extra2,
+                    ..Default::default()
+                },
+            ])),
+            ..Default::default()
+        };
+
+        let result = resolve_assets(&plugin, &section, project_root, &output_dir);
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("asset path collision"),
+            "expected collision error, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_resolve_assets_absolute_override_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        // Create a file at an absolute path outside the project root
+        let abs_css = std::env::temp_dir().join("rheo_test_absolute.css");
+        std::fs::write(&abs_css, "body {}").unwrap();
+
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "css_stylesheet",
+                default_path: "style.css",
+                required: false,
+            }],
+        };
+
+        let mut asset_extra = toml::map::Map::new();
+        asset_extra.insert(
+            "css_stylesheet".into(),
+            toml::Value::String(abs_css.to_str().unwrap().into()),
+        );
+        let section = PluginSection {
+            assets: Some(AssetsField::Single(PluginAssets {
+                extra: asset_extra,
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let result = resolve_assets(&plugin, &section, project_root, &output_dir);
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("absolute or outside the project root"),
+            "expected absolute path error, got: {}",
+            err_msg
+        );
+
+        // Clean up
+        let _ = std::fs::remove_file(&abs_css);
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -598,10 +598,7 @@ fn perform_compilation(
             for pattern in block.copy.iter() {
                 let abs_pattern = project.root.join(pattern).display().to_string();
                 let entries = glob::glob(&abs_pattern).map_err(|e| {
-                    RheoError::project_config(format!(
-                        "invalid copy pattern '{}': {}",
-                        pattern, e
-                    ))
+                    RheoError::project_config(format!("invalid copy pattern '{}': {}", pattern, e))
                 })?;
                 let mut matched = false;
                 for entry in entries.filter_map(|e| e.ok()).filter(|p| p.is_file()) {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -369,8 +369,15 @@ fn compile_one_file(
     Ok(())
 }
 
-/// Copy each source file verbatim into the build dir, preserving its path relative to the project root.
-fn copy_each(sources: &[PathBuf], project_root: &Path, build_dir: &Path) -> Result<Vec<PathBuf>> {
+/// Copy each source file verbatim into the build dir.
+/// When `strip_to_basename` is true, only the filename is used (for dest-prefixed dirs).
+/// Otherwise the project-root-relative path is preserved.
+fn copy_each(
+    sources: &[PathBuf],
+    project_root: &Path,
+    build_dir: &Path,
+    strip_to_basename: bool,
+) -> Result<Vec<PathBuf>> {
     let mut out = Vec::with_capacity(sources.len());
     for src in sources {
         let rel = src.strip_prefix(project_root).map_err(|_| {
@@ -379,7 +386,11 @@ fn copy_each(sources: &[PathBuf], project_root: &Path, build_dir: &Path) -> Resu
                 src.display()
             ))
         })?;
-        let dest = build_dir.join(rel);
+        let dest = if strip_to_basename {
+            build_dir.join(src.file_name().expect("source must have a filename"))
+        } else {
+            build_dir.join(rel)
+        };
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
                 RheoError::io(
@@ -399,7 +410,9 @@ fn copy_each(sources: &[PathBuf], project_root: &Path, build_dir: &Path) -> Resu
 }
 
 /// Resolve plugin assets, collecting overrides across all [[plugin.assets]] blocks
-/// and copying each source verbatim into the plugin output dir.
+/// and copying each source verbatim into the plugin output dir. When a block
+/// has `dest` set, named assets are placed under that subdirectory with their
+/// directory components stripped (basename only).
 fn resolve_assets(
     plugin: &dyn FormatPlugin,
     plugin_section: &PluginSection,
@@ -409,73 +422,105 @@ fn resolve_assets(
     let mut resolved = HashMap::new();
     let mut seen_relative_paths: HashMap<String, PathBuf> = HashMap::new();
     for asset_config in plugin.assets() {
-        let overrides: Vec<&str> = plugin_section.get_strings(asset_config.name);
-        let effective: Vec<&str> = if overrides.is_empty() {
-            vec![asset_config.default_path]
+        let pairs = plugin_section.get_strings_with_block(asset_config.name);
+        let effective: Vec<(Option<&str>, &str)> = if pairs.is_empty() {
+            vec![(None, asset_config.default_path)]
         } else {
-            overrides
+            pairs
+                .into_iter()
+                .map(|(b, p)| (b.dest.as_deref(), p))
+                .collect()
         };
 
-        let mut sources: Vec<PathBuf> = Vec::new();
-        let mut missing: Vec<&str> = Vec::new();
-        for path in &effective {
-            let abs = project_root.join(path);
-            if abs.is_file() {
-                sources.push(abs);
+        // Group sources by dest, preserving insertion order.
+        let mut groups: Vec<(Option<&str>, Vec<&str>)> = Vec::new();
+        for (dest, path) in &effective {
+            if let Some(group) = groups.iter_mut().find(|(d, _)| *d == *dest) {
+                group.1.push(*path);
             } else {
-                missing.push(path);
+                groups.push((*dest, vec![*path]));
             }
         }
 
-        if sources.is_empty() {
+        let mut all_assets: Vec<Asset> = Vec::new();
+        let mut any_source_found = false;
+
+        for (dest, paths) in &groups {
+            let out_dir = match dest {
+                Some(d) => plugin_output_dir.join(d),
+                None => plugin_output_dir.to_path_buf(),
+            };
+
+            let mut sources: Vec<PathBuf> = Vec::new();
+            let mut missing: Vec<&str> = Vec::new();
+            for path in paths {
+                let abs = project_root.join(path);
+                if abs.is_file() {
+                    sources.push(abs);
+                } else {
+                    missing.push(path);
+                }
+            }
+
+            if sources.is_empty() {
+                continue;
+            }
+            any_source_found = true;
+
+            for m in &missing {
+                warn!(
+                    plugin = plugin.name(),
+                    asset = asset_config.name,
+                    path = %m,
+                    "asset override path not found, skipping"
+                );
+            }
+
+            let outputs: Vec<PathBuf> =
+                copy_each(&sources, project_root, &out_dir, dest.is_some())?;
+
+            let assets: Vec<Asset> = outputs
+                .into_iter()
+                .map(|abs| {
+                    let rel = abs
+                        .strip_prefix(plugin_output_dir)
+                        .expect("copy_each output is always under plugin_output_dir")
+                        .to_string_lossy()
+                        .into_owned();
+                    if let Some(prev) = seen_relative_paths.get(&rel) {
+                        return Err(RheoError::project_config(format!(
+                            "asset path collision: '{}' produced by both '{}' and '{}'",
+                            rel,
+                            prev.display(),
+                            abs.display()
+                        )));
+                    }
+                    seen_relative_paths.insert(rel.clone(), abs.clone());
+                    Ok(Asset {
+                        config: asset_config.clone(),
+                        resolved_path: abs,
+                        built_relative_path: rel,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            all_assets.extend(assets);
+        }
+
+        if !any_source_found {
             if asset_config.required {
+                let paths: Vec<&str> = effective.iter().map(|(_, p)| *p).collect();
                 return Err(RheoError::project_config(format!(
                     "plugin '{}' requires input '{}' but no source was found (tried: {})",
                     plugin.name(),
                     asset_config.name,
-                    effective.join(", ")
+                    paths.join(", ")
                 )));
             }
             continue;
         }
 
-        for m in &missing {
-            warn!(
-                plugin = plugin.name(),
-                asset = asset_config.name,
-                path = %m,
-                "asset override path not found, skipping"
-            );
-        }
-
-        let outputs: Vec<PathBuf> = copy_each(&sources, project_root, plugin_output_dir)?;
-
-        let assets: Vec<Asset> = outputs
-            .into_iter()
-            .map(|abs| {
-                let rel = abs
-                    .strip_prefix(plugin_output_dir)
-                    .expect("copy_each output is always under plugin_output_dir")
-                    .to_string_lossy()
-                    .into_owned();
-                if let Some(prev) = seen_relative_paths.get(&rel) {
-                    return Err(RheoError::project_config(format!(
-                        "asset path collision: '{}' produced by both '{}' and '{}'",
-                        rel,
-                        prev.display(),
-                        abs.display()
-                    )));
-                }
-                seen_relative_paths.insert(rel.clone(), abs.clone());
-                Ok(Asset {
-                    config: asset_config.clone(),
-                    resolved_path: abs,
-                    built_relative_path: rel,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        resolved.insert(asset_config.name, assets);
+        resolved.insert(asset_config.name, all_assets);
     }
     Ok(resolved)
 }
@@ -1468,5 +1513,139 @@ mod tests {
 
         // Clean up
         let _ = std::fs::remove_file(&abs_css);
+    }
+
+    #[test]
+    fn test_resolve_assets_dest_places_in_subdirectory() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        std::fs::write(project_root.join("custom.css"), "/* custom */").unwrap();
+
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "css_stylesheet",
+                default_path: "style.css",
+                required: false,
+            }],
+        };
+
+        let mut extra = toml::map::Map::new();
+        extra.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("custom.css".into()),
+        );
+        let section = PluginSection {
+            assets: Some(AssetsField::Multiple(vec![PluginAssets {
+                extra,
+                dest: Some("subdir".into()),
+                ..Default::default()
+            }])),
+            ..Default::default()
+        };
+
+        let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
+        let assets = resolved.get("css_stylesheet").unwrap();
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0].built_relative_path, "subdir/custom.css");
+        assert!(output_dir.join("subdir/custom.css").exists());
+    }
+
+    #[test]
+    fn test_resolve_assets_mixed_dest_and_no_dest() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        std::fs::write(project_root.join("root.css"), "/* root */").unwrap();
+        std::fs::write(project_root.join("dest.css"), "/* dest */").unwrap();
+
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "css_stylesheet",
+                default_path: "style.css",
+                required: false,
+            }],
+        };
+
+        let mut extra1 = toml::map::Map::new();
+        extra1.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("root.css".into()),
+        );
+        let mut extra2 = toml::map::Map::new();
+        extra2.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("dest.css".into()),
+        );
+        let section = PluginSection {
+            assets: Some(AssetsField::Multiple(vec![
+                PluginAssets {
+                    extra: extra1,
+                    ..Default::default()
+                },
+                PluginAssets {
+                    extra: extra2,
+                    dest: Some("assets".into()),
+                    ..Default::default()
+                },
+            ])),
+            ..Default::default()
+        };
+
+        let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
+        let assets = resolved.get("css_stylesheet").unwrap();
+        assert_eq!(assets.len(), 2);
+        assert!(output_dir.join("root.css").exists());
+        assert!(output_dir.join("assets/dest.css").exists());
+    }
+
+    #[test]
+    fn test_resolve_assets_dest_strips_to_basename() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let output_dir = dir.path().join("build/html");
+        std::fs::create_dir_all(&output_dir).unwrap();
+
+        std::fs::create_dir_all(project_root.join("dist")).unwrap();
+        std::fs::write(project_root.join("dist/index.js"), "// js").unwrap();
+
+        let plugin = MockPlugin {
+            plugin_name: "html",
+            declared_assets: vec![AssetConfig {
+                name: "js_scripts",
+                default_path: "script.js",
+                required: false,
+            }],
+        };
+
+        let mut extra = toml::map::Map::new();
+        extra.insert(
+            "js_scripts".into(),
+            toml::Value::String("dist/index.js".into()),
+        );
+        let section = PluginSection {
+            assets: Some(AssetsField::Multiple(vec![PluginAssets {
+                extra,
+                dest: Some("allassets".into()),
+                ..Default::default()
+            }])),
+            ..Default::default()
+        };
+
+        let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
+        let assets = resolved.get("js_scripts").unwrap();
+        assert_eq!(assets.len(), 1);
+        assert_eq!(assets[0].built_relative_path, "allassets/index.js");
+        assert!(output_dir.join("allassets/index.js").exists());
+        assert!(
+            !output_dir.join("allassets/dist/index.js").exists(),
+            "source directory components should be stripped under dest"
+        );
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -369,13 +369,8 @@ fn compile_one_file(
     Ok(())
 }
 
-/// Default combiner used when AssetConfig.combine is None: copies each source
-/// verbatim into the build dir, preserving its path relative to the project root.
-fn default_copy_each(
-    sources: &[PathBuf],
-    project_root: &Path,
-    build_dir: &Path,
-) -> Result<Vec<PathBuf>> {
+/// Copy each source file verbatim into the build dir, preserving its path relative to the project root.
+fn copy_each(sources: &[PathBuf], project_root: &Path, build_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut out = Vec::with_capacity(sources.len());
     for src in sources {
         let rel = src
@@ -449,10 +444,7 @@ fn resolve_assets(
             );
         }
 
-        let outputs: Vec<PathBuf> = match asset_config.combine {
-            Some(c) => c.combine(&sources, plugin_output_dir)?,
-            None => default_copy_each(&sources, project_root, plugin_output_dir)?,
-        };
+        let outputs: Vec<PathBuf> = copy_each(&sources, project_root, plugin_output_dir)?;
 
         let assets: Vec<Asset> = outputs
             .into_iter()
@@ -993,8 +985,8 @@ fn run_clean(sub: &ArgMatches) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rheo_core::AssetConfig;
     use rheo_core::config::{AssetsField, PluginAssets};
-    use rheo_core::{AssetCombine, AssetConfig};
 
     #[test]
     fn test_determine_formats_cli_flags_override_config() {
@@ -1092,7 +1084,6 @@ mod tests {
                 name: "css_stylesheet",
                 default_path: "style.css",
                 required: false,
-                combine: None,
             }],
         };
         let section = PluginSection::default();
@@ -1119,7 +1110,6 @@ mod tests {
                 name: "css_stylesheet",
                 default_path: "style.css",
                 required: false,
-                combine: None,
             }],
         };
         let mut asset_extra = toml::map::Map::new();
@@ -1155,7 +1145,6 @@ mod tests {
                 name: "missing_asset",
                 default_path: "nonexistent.css",
                 required: true,
-                combine: None,
             }],
         };
         let section = PluginSection::default();
@@ -1182,7 +1171,6 @@ mod tests {
                 name: "optional_asset",
                 default_path: "nonexistent.css",
                 required: false,
-                combine: None,
             }],
         };
         let section = PluginSection::default();
@@ -1211,7 +1199,6 @@ mod tests {
                 name: "css_stylesheet",
                 default_path: "style.css",
                 required: false,
-                combine: None,
             }],
         };
         let mut asset_extra = toml::map::Map::new();
@@ -1239,7 +1226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_assets_multiple_blocks_default_copy_each() {
+    fn test_resolve_assets_multiple_blocks_copy_each() {
         let dir = tempfile::tempdir().unwrap();
         let project_root = dir.path();
         let output_dir = dir.path().join("build/html");
@@ -1254,7 +1241,6 @@ mod tests {
                 name: "css_stylesheet",
                 default_path: "style.css",
                 required: false,
-                combine: None,
             }],
         };
 
@@ -1289,74 +1275,6 @@ mod tests {
         assert!(output_dir.join("two.css").exists());
     }
 
-    struct MockConcat;
-
-    impl AssetCombine for MockConcat {
-        fn combine(
-            &self,
-            sources: &[PathBuf],
-            build_dir: &Path,
-        ) -> rheo_core::Result<Vec<PathBuf>> {
-            let mut content = String::new();
-            for s in sources {
-                content.push_str(&std::fs::read_to_string(s).unwrap());
-            }
-            let dest = build_dir.join("combined.css");
-            std::fs::write(&dest, &content)
-                .map_err(|e| rheo_core::RheoError::io(e, "writing combined asset"))?;
-            Ok(vec![dest])
-        }
-    }
-
-    #[test]
-    fn test_resolve_assets_invokes_custom_combiner() {
-        let dir = tempfile::tempdir().unwrap();
-        let project_root = dir.path();
-        let output_dir = dir.path().join("build/html");
-        std::fs::create_dir_all(&output_dir).unwrap();
-
-        std::fs::write(project_root.join("a.css"), "/* a */").unwrap();
-        std::fs::write(project_root.join("b.css"), "/* b */").unwrap();
-
-        static COMBINER: MockConcat = MockConcat;
-        let plugin = MockPlugin {
-            plugin_name: "html",
-            declared_assets: vec![AssetConfig {
-                name: "css_stylesheet",
-                default_path: "style.css",
-                required: false,
-                combine: Some(&COMBINER),
-            }],
-        };
-
-        let mut extra1 = toml::map::Map::new();
-        extra1.insert("css_stylesheet".into(), toml::Value::String("a.css".into()));
-        let mut extra2 = toml::map::Map::new();
-        extra2.insert("css_stylesheet".into(), toml::Value::String("b.css".into()));
-        let section = PluginSection {
-            assets: Some(AssetsField::Multiple(vec![
-                PluginAssets {
-                    extra: extra1,
-                    ..Default::default()
-                },
-                PluginAssets {
-                    extra: extra2,
-                    ..Default::default()
-                },
-            ])),
-            ..Default::default()
-        };
-
-        let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
-        let assets = resolved.get("css_stylesheet").unwrap();
-        assert_eq!(assets.len(), 1);
-        assert!(output_dir.join("combined.css").exists());
-        assert_eq!(
-            std::fs::read_to_string(output_dir.join("combined.css")).unwrap(),
-            "/* a *//* b */"
-        );
-    }
-
     #[test]
     fn test_resolve_assets_required_all_missing_errors() {
         let dir = tempfile::tempdir().unwrap();
@@ -1370,7 +1288,6 @@ mod tests {
                 name: "missing_asset",
                 default_path: "nonexistent.css",
                 required: true,
-                combine: None,
             }],
         };
         let section = PluginSection::default();
@@ -1399,7 +1316,6 @@ mod tests {
                 name: "css_stylesheet",
                 default_path: "style.css",
                 required: true,
-                combine: None,
             }],
         };
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -462,11 +462,9 @@ fn perform_compilation(
         // Execute copy patterns (global + per-plugin)
         for pattern in project.config.copy.iter().chain(
             plugin_section
-                .assets
-                .as_ref()
-                .map(|a| a.copy.iter())
-                .into_iter()
-                .flatten(),
+                .asset_blocks()
+                .iter()
+                .flat_map(|b| b.copy.iter()),
         ) {
             let abs_pattern = project.root.join(pattern).display().to_string();
             let entries = glob::glob(&abs_pattern).map_err(|e| {
@@ -943,7 +941,7 @@ fn run_clean(sub: &ArgMatches) -> Result<()> {
 mod tests {
     use super::*;
     use rheo_core::AssetConfig;
-    use rheo_core::config::PluginAssets;
+    use rheo_core::config::{AssetsField, PluginAssets};
 
     #[test]
     fn test_determine_formats_cli_flags_override_config() {
@@ -1077,10 +1075,10 @@ mod tests {
             toml::Value::String("custom.css".into()),
         );
         let section = PluginSection {
-            assets: Some(PluginAssets {
+            assets: Some(AssetsField::Single(PluginAssets {
                 extra: asset_extra,
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
 
@@ -1169,10 +1167,10 @@ mod tests {
             toml::Value::String("styles/custom.css".into()),
         );
         let section = PluginSection {
-            assets: Some(PluginAssets {
+            assets: Some(AssetsField::Single(PluginAssets {
                 extra: asset_extra,
                 ..Default::default()
-            }),
+            })),
             ..Default::default()
         };
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -993,8 +993,8 @@ fn run_clean(sub: &ArgMatches) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rheo_core::{AssetCombine, AssetConfig};
     use rheo_core::config::{AssetsField, PluginAssets};
+    use rheo_core::{AssetCombine, AssetConfig};
 
     #[test]
     fn test_determine_formats_cli_flags_override_config() {
@@ -1259,13 +1259,25 @@ mod tests {
         };
 
         let mut extra1 = toml::map::Map::new();
-        extra1.insert("css_stylesheet".into(), toml::Value::String("one.css".into()));
+        extra1.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("one.css".into()),
+        );
         let mut extra2 = toml::map::Map::new();
-        extra2.insert("css_stylesheet".into(), toml::Value::String("two.css".into()));
+        extra2.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("two.css".into()),
+        );
         let section = PluginSection {
             assets: Some(AssetsField::Multiple(vec![
-                PluginAssets { extra: extra1, ..Default::default() },
-                PluginAssets { extra: extra2, ..Default::default() },
+                PluginAssets {
+                    extra: extra1,
+                    ..Default::default()
+                },
+                PluginAssets {
+                    extra: extra2,
+                    ..Default::default()
+                },
             ])),
             ..Default::default()
         };
@@ -1323,8 +1335,14 @@ mod tests {
         extra2.insert("css_stylesheet".into(), toml::Value::String("b.css".into()));
         let section = PluginSection {
             assets: Some(AssetsField::Multiple(vec![
-                PluginAssets { extra: extra1, ..Default::default() },
-                PluginAssets { extra: extra2, ..Default::default() },
+                PluginAssets {
+                    extra: extra1,
+                    ..Default::default()
+                },
+                PluginAssets {
+                    extra: extra2,
+                    ..Default::default()
+                },
             ])),
             ..Default::default()
         };
@@ -1386,13 +1404,25 @@ mod tests {
         };
 
         let mut extra1 = toml::map::Map::new();
-        extra1.insert("css_stylesheet".into(), toml::Value::String("exists.css".into()));
+        extra1.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("exists.css".into()),
+        );
         let mut extra2 = toml::map::Map::new();
-        extra2.insert("css_stylesheet".into(), toml::Value::String("missing.css".into()));
+        extra2.insert(
+            "css_stylesheet".into(),
+            toml::Value::String("missing.css".into()),
+        );
         let section = PluginSection {
             assets: Some(AssetsField::Multiple(vec![
-                PluginAssets { extra: extra1, ..Default::default() },
-                PluginAssets { extra: extra2, ..Default::default() },
+                PluginAssets {
+                    extra: extra1,
+                    ..Default::default()
+                },
+                PluginAssets {
+                    extra: extra2,
+                    ..Default::default()
+                },
             ])),
             ..Default::default()
         };

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -331,7 +331,7 @@ struct PerFileCtx<'a> {
     output_config: &'a OutputConfig,
     spine: &'a SpineOptions,
     plugin_section: &'a PluginSection,
-    resolved_assets: &'a HashMap<&'static str, Asset>,
+    resolved_assets: &'a HashMap<&'static str, Vec<Asset>>,
 }
 
 /// Compile one file with the given world, recording success/failure in `results`.
@@ -379,7 +379,7 @@ fn resolve_assets(
     plugin_section: &PluginSection,
     project_root: &Path,
     plugin_output_dir: &Path,
-) -> Result<HashMap<&'static str, Asset>> {
+) -> Result<HashMap<&'static str, Vec<Asset>>> {
     let mut resolved = HashMap::new();
     for asset_config in plugin.assets() {
         let effective_path: &str = plugin_section
@@ -404,11 +404,11 @@ fn resolve_assets(
             })?;
             resolved.insert(
                 asset_config.name,
-                Asset {
+                vec![Asset {
                     config: asset_config.clone(),
                     resolved_path: dest,
                     built_relative_path: effective_path.to_string(),
-                },
+                }],
             );
         } else if asset_config.required {
             return Err(RheoError::project_config(format!(
@@ -1046,7 +1046,7 @@ mod tests {
 
         let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
         assert_eq!(
-            resolved.get("css_stylesheet").unwrap().built_relative_path,
+            resolved.get("css_stylesheet").unwrap()[0].built_relative_path,
             "style.css"
         );
     }
@@ -1084,7 +1084,7 @@ mod tests {
 
         let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
         assert_eq!(
-            resolved.get("css_stylesheet").unwrap().built_relative_path,
+            resolved.get("css_stylesheet").unwrap()[0].built_relative_path,
             "custom.css"
         );
     }
@@ -1176,7 +1176,7 @@ mod tests {
 
         let resolved = resolve_assets(&plugin, &section, project_root, &output_dir).unwrap();
         assert_eq!(
-            resolved.get("css_stylesheet").unwrap().built_relative_path,
+            resolved.get("css_stylesheet").unwrap()[0].built_relative_path,
             "styles/custom.css"
         );
         assert!(

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -44,6 +44,30 @@ pub struct PluginAssets {
     pub extra: toml::Table,
 }
 
+/// Accepts either `[plugin.assets]` (single table) or `[[plugin.assets]]` (array-of-tables).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AssetsField {
+    Single(PluginAssets),
+    Multiple(Vec<PluginAssets>),
+}
+
+impl Default for AssetsField {
+    fn default() -> Self {
+        AssetsField::Multiple(Vec::new())
+    }
+}
+
+impl AssetsField {
+    /// Normalised view: a slice of asset blocks regardless of source syntax.
+    pub fn blocks(&self) -> &[PluginAssets] {
+        match self {
+            AssetsField::Single(a) => std::slice::from_ref(a),
+            AssetsField::Multiple(v) => v.as_slice(),
+        }
+    }
+}
+
 /// Plugin section for `[plugin_name]` in rheo.toml.
 ///
 /// Contains the universal `spine` field plus format-specific extra fields in
@@ -57,7 +81,7 @@ pub struct PluginSection {
 
     /// Asset configuration subtable (`[plugin_name.assets]`).
     /// Holds glob copy patterns and AssetConfig path overrides.
-    pub assets: Option<PluginAssets>,
+    pub assets: Option<AssetsField>,
 
     /// Plugin-specific extra fields from the TOML section (e.g. `stylesheets`,
     /// `fonts` for HTML; `identifier`, `date` for EPUB).
@@ -241,12 +265,25 @@ impl RheoConfig {
 }
 
 impl PluginSection {
+    /// Returns the asset blocks, normalised to a slice regardless of source syntax.
+    pub fn asset_blocks(&self) -> &[PluginAssets] {
+        self.assets.as_ref().map(|a| a.blocks()).unwrap_or(&[])
+    }
+
     /// Get a string value from the `[plugin.assets]` overrides, returning None if absent or not a string.
+    /// Returns the first override found across all asset blocks.
     pub fn get_string(&self, key: &str) -> Option<&str> {
-        self.assets
-            .as_ref()
-            .and_then(|a| a.extra.get(key))
-            .and_then(|v| v.as_str())
+        self.asset_blocks()
+            .iter()
+            .find_map(|b| b.extra.get(key).and_then(|v| v.as_str()))
+    }
+
+    /// Collect every override for `key` across all asset blocks, in declared order.
+    pub fn get_strings(&self, key: &str) -> Vec<&str> {
+        self.asset_blocks()
+            .iter()
+            .filter_map(|b| b.extra.get(key).and_then(|v| v.as_str()))
+            .collect()
     }
 }
 
@@ -509,7 +546,7 @@ mod tests {
         let config = parse(&toml);
         let section = config.plugin_section("html");
         assert_eq!(
-            section.assets.as_ref().unwrap().copy,
+            section.asset_blocks()[0].copy,
             vec!["assets/logo.png", "fonts/**"]
         );
     }
@@ -520,8 +557,7 @@ mod tests {
         let config = parse(&toml);
         let section = config.plugin_section("html");
         // `copy` must be in PluginAssets.copy, not leaked into PluginAssets.extra
-        let assets = section.assets.as_ref().unwrap();
-        assert!(assets.extra.get("copy").is_none());
+        assert!(section.asset_blocks()[0].extra.get("copy").is_none());
     }
 
     #[test]
@@ -579,5 +615,56 @@ mod tests {
         let base_dir = PathBuf::from("/project");
         let resolved = config.resolve_font_dirs(&base_dir);
         assert_eq!(resolved, vec![PathBuf::from("/project/fonts")]);
+    }
+
+    #[test]
+    fn test_assets_array_of_tables_parses() {
+        let toml = versioned_toml(
+            "[[html.assets]]\njs_scripts = \"one.js\"\n[[html.assets]]\njs_scripts = \"two.js\"",
+        );
+        let config = parse(&toml);
+        let section = config.plugin_section("html");
+        assert_eq!(section.asset_blocks().len(), 2);
+        assert_eq!(
+            section.get_strings("js_scripts"),
+            vec!["one.js", "two.js"]
+        );
+    }
+
+    #[test]
+    fn test_assets_single_table_still_parses() {
+        let toml = versioned_toml("[html.assets]\njs_scripts = \"one.js\"");
+        let config = parse(&toml);
+        let section = config.plugin_section("html");
+        assert_eq!(section.asset_blocks().len(), 1);
+        assert_eq!(section.get_string("js_scripts"), Some("one.js"));
+    }
+
+    #[test]
+    fn test_get_strings_collects_across_blocks() {
+        let toml = versioned_toml(
+            "[[html.assets]]\ncss_stylesheet = \"a.css\"\n[[html.assets]]\ncss_stylesheet = \"b.css\"",
+        );
+        let config = parse(&toml);
+        let section = config.plugin_section("html");
+        assert_eq!(section.get_strings("css_stylesheet"), vec!["a.css", "b.css"]);
+    }
+
+    #[test]
+    fn test_get_string_returns_first_match_across_blocks() {
+        let toml = versioned_toml(
+            "[[html.assets]]\ncss_stylesheet = \"first.css\"\n[[html.assets]]\ncss_stylesheet = \"second.css\"",
+        );
+        let config = parse(&toml);
+        let section = config.plugin_section("html");
+        assert_eq!(section.get_string("css_stylesheet"), Some("first.css"));
+    }
+
+    #[test]
+    fn test_asset_blocks_empty_when_no_assets_field() {
+        let toml = versioned_toml("[html]\nstylesheets = [\"style.css\"]");
+        let config = parse(&toml);
+        let section = config.plugin_section("html");
+        assert!(section.asset_blocks().is_empty());
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -52,12 +52,6 @@ pub enum AssetsField {
     Multiple(Vec<PluginAssets>),
 }
 
-impl Default for AssetsField {
-    fn default() -> Self {
-        AssetsField::Multiple(Vec::new())
-    }
-}
-
 impl AssetsField {
     /// Normalised view: a slice of asset blocks regardless of source syntax.
     pub fn blocks(&self) -> &[PluginAssets] {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -625,10 +625,7 @@ mod tests {
         let config = parse(&toml);
         let section = config.plugin_section("html");
         assert_eq!(section.asset_blocks().len(), 2);
-        assert_eq!(
-            section.get_strings("js_scripts"),
-            vec!["one.js", "two.js"]
-        );
+        assert_eq!(section.get_strings("js_scripts"), vec!["one.js", "two.js"]);
     }
 
     #[test]
@@ -647,7 +644,10 @@ mod tests {
         );
         let config = parse(&toml);
         let section = config.plugin_section("html");
-        assert_eq!(section.get_strings("css_stylesheet"), vec!["a.css", "b.css"]);
+        assert_eq!(
+            section.get_strings("css_stylesheet"),
+            vec!["a.css", "b.css"]
+        );
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -28,15 +28,26 @@ pub struct Spine {
 
 /// Asset configuration for `[plugin_name.assets]` in rheo.toml.
 ///
-/// Holds both glob copy patterns (`copy`) and AssetConfig path overrides
-/// (any other key). Separating these into their own subtable ensures AssetConfig
-/// names cannot clash with other `[plugin_name]` fields like `spine`.
+/// Holds glob copy patterns (`copy`), an optional destination subdirectory
+/// (`dest`), and AssetConfig path overrides (any other key). Separating these
+/// into their own subtable ensures AssetConfig names cannot clash with other
+/// `[plugin_name]` fields like `spine`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PluginAssets {
     /// Glob patterns for files to copy into this plugin's output directory.
     /// Paths are relative to the project root; directory structure is preserved.
     #[serde(default)]
     pub copy: Vec<String>,
+
+    /// Optional destination subdirectory (relative to plugin output dir)
+    /// for every file produced by this block. When set:
+    /// - named asset overrides (e.g. `js_scripts`) are placed at
+    ///   `<plugin_output_dir>/<dest>/<basename>` (source directory stripped);
+    /// - `copy` glob matches are placed at
+    ///   `<plugin_output_dir>/<dest>/<rel>` where `<rel>` is the source's
+    ///   project-root-relative path (structure preserved).
+    #[serde(default)]
+    pub dest: Option<String>,
 
     /// AssetConfig path overrides, keyed by the AssetConfig name
     /// (e.g. `css_stylesheet = "custom.css"`).
@@ -277,6 +288,16 @@ impl PluginSection {
         self.asset_blocks()
             .iter()
             .filter_map(|b| b.extra.get(key).and_then(|v| v.as_str()))
+            .collect()
+    }
+
+    /// Collect every (block, override-value) pair for `key` across all
+    /// asset blocks, in declared order. Used by callers that need each
+    /// block's `dest` to compute output paths.
+    pub fn get_strings_with_block(&self, key: &str) -> Vec<(&PluginAssets, &str)> {
+        self.asset_blocks()
+            .iter()
+            .filter_map(|b| b.extra.get(key).and_then(|v| v.as_str()).map(|s| (b, s)))
             .collect()
     }
 }
@@ -660,5 +681,39 @@ mod tests {
         let config = parse(&toml);
         let section = config.plugin_section("html");
         assert!(section.asset_blocks().is_empty());
+    }
+
+    #[test]
+    fn test_dest_field_parses() {
+        let toml =
+            versioned_toml("[html.assets]\ndest = \"allassets\"\ncss_stylesheet = \"custom.css\"");
+        let config = parse(&toml);
+        let section = config.plugin_section("html");
+        let blocks = section.asset_blocks();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].dest.as_deref(), Some("allassets"));
+    }
+
+    #[test]
+    fn test_dest_defaults_to_none() {
+        let toml = versioned_toml("[html.assets]\ncss_stylesheet = \"custom.css\"");
+        let config = parse(&toml);
+        let section = config.plugin_section("html");
+        assert!(section.asset_blocks()[0].dest.is_none());
+    }
+
+    #[test]
+    fn test_get_strings_with_block_returns_pairs() {
+        let toml = versioned_toml(
+            "[[html.assets]]\njs_scripts = \"one.js\"\ndest = \"subdir\"\n[[html.assets]]\njs_scripts = \"two.js\"",
+        );
+        let config = parse(&toml);
+        let section = config.plugin_section("html");
+        let pairs = section.get_strings_with_block("js_scripts");
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].1, "one.js");
+        assert_eq!(pairs[0].0.dest.as_deref(), Some("subdir"));
+        assert_eq!(pairs[1].1, "two.js");
+        assert!(pairs[1].0.dest.is_none());
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,7 +40,7 @@ pub use config::{PluginAssets, PluginSection, Spine};
 
 // Plugin trait and context
 pub use plugins::{
-    AssetConfig, FormatPlugin, OpenHandle, PluginContext, ServerHandle, SpineOptions,
+    AssetCombine, AssetConfig, FormatPlugin, OpenHandle, PluginContext, ServerHandle, SpineOptions,
 };
 
 // HTML/PDF export utilities

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,7 +40,7 @@ pub use config::{AssetsField, PluginAssets, PluginSection, Spine};
 
 // Plugin trait and context
 pub use plugins::{
-    AssetCombine, AssetConfig, FormatPlugin, OpenHandle, PluginContext, ServerHandle, SpineOptions,
+    AssetConfig, FormatPlugin, OpenHandle, PluginContext, ServerHandle, SpineOptions,
 };
 
 // HTML/PDF export utilities

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -36,7 +36,7 @@ pub use results::{CompilationResults, FormatResult};
 pub use compile::RheoCompileOptions;
 
 // Configuration types
-pub use config::{PluginAssets, PluginSection, Spine};
+pub use config::{AssetsField, PluginAssets, PluginSection, Spine};
 
 // Plugin trait and context
 pub use plugins::{

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -111,7 +111,7 @@ pub struct PluginContext<'a> {
     /// Paths are relative to the plugin's output directory (e.g., `build/html/`).
     /// The CLI copies each declared input from the project root to the output directory
     /// before calling `compile()`.
-    pub assets: &'a HashMap<&'static str, Asset>,
+    pub assets: &'a HashMap<&'static str, Vec<Asset>>,
 }
 
 impl<'a> PluginContext<'a> {

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -38,8 +38,18 @@ pub struct SpineOptions {
     pub merge: bool,
 }
 
+/// Strategy for materialising one or more source files for a single AssetConfig
+/// into the plugin's build directory. Implementations are stateless static singletons.
+pub trait AssetCombine: Send + Sync {
+    /// Combine `sources` (absolute paths under the project root) into files
+    /// under `build_dir` (the plugin's output directory). Returns the absolute
+    /// paths of the produced files, in the order they should be presented to
+    /// the consuming plugin (e.g., link injection order).
+    fn combine(&self, sources: &[PathBuf], build_dir: &Path) -> crate::Result<Vec<PathBuf>>;
+}
+
 /// Declares an additional non-Typst input file needed from the project directory.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AssetConfig {
     /// Key used to retrieve this input from PluginContext::inputs
     pub name: &'static str,
@@ -48,6 +58,19 @@ pub struct AssetConfig {
     pub default_path: &'static str,
     /// If true, a missing file is a compile error; if false, it is absent from ctx.inputs
     pub required: bool,
+    /// Combine strategy. None = use the built-in default (copy each source
+    /// verbatim, preserving its path relative to the project root).
+    pub combine: Option<&'static dyn AssetCombine>,
+}
+
+impl std::fmt::Debug for AssetConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AssetConfig")
+            .field("name", &self.name)
+            .field("default_path", &self.default_path)
+            .field("required", &self.required)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -38,18 +38,8 @@ pub struct SpineOptions {
     pub merge: bool,
 }
 
-/// Strategy for materialising one or more source files for a single AssetConfig
-/// into the plugin's build directory. Implementations are stateless static singletons.
-pub trait AssetCombine: Send + Sync {
-    /// Combine `sources` (absolute paths under the project root) into files
-    /// under `build_dir` (the plugin's output directory). Returns the absolute
-    /// paths of the produced files, in the order they should be presented to
-    /// the consuming plugin (e.g., link injection order).
-    fn combine(&self, sources: &[PathBuf], build_dir: &Path) -> crate::Result<Vec<PathBuf>>;
-}
-
 /// Declares an additional non-Typst input file needed from the project directory.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AssetConfig {
     /// Key used to retrieve this input from PluginContext::inputs
     pub name: &'static str,
@@ -58,19 +48,6 @@ pub struct AssetConfig {
     pub default_path: &'static str,
     /// If true, a missing file is a compile error; if false, it is absent from ctx.inputs
     pub required: bool,
-    /// Combine strategy. None = use the built-in default (copy each source
-    /// verbatim, preserving its path relative to the project root).
-    pub combine: Option<&'static dyn AssetCombine>,
-}
-
-impl std::fmt::Debug for AssetConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AssetConfig")
-            .field("name", &self.name)
-            .field("default_path", &self.default_path)
-            .field("required", &self.required)
-            .finish()
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -103,23 +103,23 @@ impl FormatPlugin for HtmlPlugin {
     fn compile(&self, ctx: PluginContext<'_>) -> Result<()> {
         let html_string = ctx.compile_to_html_string()?;
 
-        // If a custom asset is specified, we inject the link to the asset into each HTML file.
-        // If not, we inline the default CSS.
-        let html_string = if let Some(css_asset) = ctx.assets.get(&STYLESHEETS) {
-            info!(
-                "Found CSS stylesheet: {}",
-                &css_asset.resolved_path.display()
-            );
-            let css_assets = vec![&css_asset.built_relative_path[..]];
+        let css_vec = ctx.assets.get(&STYLESHEETS);
+        let html_string = if let Some(css_assets) = css_vec.filter(|v| !v.is_empty()) {
+            for a in css_assets {
+                info!("Found CSS stylesheet: {}", a.resolved_path.display());
+            }
+            let css_paths: Vec<&str> = css_assets
+                .iter()
+                .map(|a| a.built_relative_path.as_str())
+                .collect();
 
-            let js_assets = if let Some(js_asset) = ctx.assets.get(&SCRIPTS) {
-                info!("Found Javascript: {}", &js_asset.resolved_path.display());
-                vec![&js_asset.built_relative_path[..]]
-            } else {
-                vec![]
-            };
+            let js_paths: Vec<&str> = ctx
+                .assets
+                .get(&SCRIPTS)
+                .map(|v| v.iter().map(|a| a.built_relative_path.as_str()).collect())
+                .unwrap_or_default();
 
-            html_utils::inject_head_links(&html_string, &[], &css_assets, &js_assets)?
+            html_utils::inject_head_links(&html_string, &[], &css_paths, &js_paths)?
         } else {
             info!("No stylesheet found, using default");
             html_utils::inject_inline_styles(&html_string, &[DEFAULT_STYLESHEET])?

--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -101,26 +101,35 @@ impl FormatPlugin for HtmlPlugin {
     fn compile(&self, ctx: PluginContext<'_>) -> Result<()> {
         let html_string = ctx.compile_to_html_string()?;
 
-        let css_vec = ctx.assets.get(&STYLESHEETS);
-        let html_string = if let Some(css_assets) = css_vec.filter(|v| !v.is_empty()) {
-            for a in css_assets {
-                info!("Found CSS stylesheet: {}", a.resolved_path.display());
+        let css_assets = ctx.assets.get(&STYLESHEETS).filter(|v| !v.is_empty());
+        let js_assets = ctx.assets.get(&SCRIPTS).filter(|v| !v.is_empty());
+
+        let (css_paths, inline_styles): (Vec<&str>, &[&str]) = match css_assets {
+            Some(assets) => {
+                for a in assets {
+                    info!("Found CSS stylesheet: {}", a.resolved_path.display());
+                }
+                let paths = assets
+                    .iter()
+                    .map(|a| a.built_relative_path.as_str())
+                    .collect();
+                (paths, &[])
             }
-            let css_paths: Vec<&str> = css_assets
-                .iter()
-                .map(|a| a.built_relative_path.as_str())
-                .collect();
+            None => {
+                info!("No stylesheet found, using default");
+                (Vec::new(), &[DEFAULT_STYLESHEET])
+            }
+        };
 
-            let js_paths: Vec<&str> = ctx
-                .assets
-                .get(&SCRIPTS)
-                .map(|v| v.iter().map(|a| a.built_relative_path.as_str()).collect())
-                .unwrap_or_default();
+        let js_paths: Vec<&str> = js_assets
+            .map(|v| v.iter().map(|a| a.built_relative_path.as_str()).collect())
+            .unwrap_or_default();
 
-            html_utils::inject_head_links(&html_string, &[], &css_paths, &js_paths)?
+        let html_string = html_utils::inject_inline_styles(&html_string, inline_styles)?;
+        let html_string = if css_paths.is_empty() && js_paths.is_empty() {
+            html_string
         } else {
-            info!("No stylesheet found, using default");
-            html_utils::inject_inline_styles(&html_string, &[DEFAULT_STYLESHEET])?
+            html_utils::inject_head_links(&html_string, &[], &css_paths, &js_paths)?
         };
 
         debug!(size = html_string.len(), "writing HTML file");

--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -89,13 +89,11 @@ impl FormatPlugin for HtmlPlugin {
                 name: STYLESHEETS,
                 default_path: "style.css",
                 required: false,
-                combine: None,
             },
             AssetConfig {
                 name: SCRIPTS,
                 default_path: "index.js",
                 required: false,
-                combine: None,
             },
         ]
     }

--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -89,11 +89,13 @@ impl FormatPlugin for HtmlPlugin {
                 name: STYLESHEETS,
                 default_path: "style.css",
                 required: false,
+                combine: None,
             },
             AssetConfig {
                 name: SCRIPTS,
                 default_path: "index.js",
                 required: false,
+                combine: None,
             },
         ]
     }

--- a/crates/tests/cases/script_injection_no_css/content/index.typ
+++ b/crates/tests/cases/script_injection_no_css/content/index.typ
@@ -1,0 +1,3 @@
+= Test
+
+Hello world.

--- a/crates/tests/cases/script_injection_no_css/index.js
+++ b/crates/tests/cases/script_injection_no_css/index.js
@@ -1,0 +1,1 @@
+console.log("loaded");

--- a/crates/tests/cases/script_injection_no_css/rheo.toml
+++ b/crates/tests/cases/script_injection_no_css/rheo.toml
@@ -1,0 +1,2 @@
+version = "0.2.1"
+formats = ["html"]

--- a/crates/tests/ref/examples/script_injection_no_css/html/index.html
+++ b/crates/tests/ref/examples/script_injection_no_css/html/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html><html><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1"><script src="index.js" defer=""></script>
+  <style>.header {
+  max-height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.header img {
+  max-height: 40px;
+}
+
+/* ============================================
+   CSS Variables
+   ============================================ */
+:root {
+  --background-color: #fdfdfd;
+  --text-color: #1a1a1a;
+  --link-color: #1a1a1a;
+  --blockquote-border: #e6e6e6;
+  --blockquote-text: #606060;
+}
+
+/* ============================================
+   Base Layout
+   ============================================ */
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 1em;
+  line-height: 1.3;
+  margin: 0 auto;
+  padding: 50px;
+  max-width: 36em;
+}
+
+/* ============================================
+   Typography
+   ============================================ */
+h1, h2, h3, h4, h5, h6 {
+  color: var(--text-color);
+  font-weight: normal;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+/* ============================================
+   Links
+   ============================================ */
+a {
+  color: var(--link-color);
+  text-decoration: underline;
+}
+
+a:hover {
+  opacity: 0.7;
+}
+
+/* ============================================
+   Lists
+   ============================================ */
+ul, ol {
+  padding-left: 2em;
+  margin: 1em 0;
+}
+
+li {}
+
+/* ============================================
+   Media
+   ============================================ */
+img, video {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 1.5em 0;
+}
+
+/* ============================================
+   Code
+   ============================================ */
+code {
+  font-family: 'Courier New', monospace;
+  background-color: #f5f5f5;
+  padding: 0.2em 0.4em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+/* ============================================
+   Blockquotes
+   ============================================ */
+blockquote {
+  margin: 1.5em 0;
+  padding-left: 1em;
+  border-left: 2px solid var(--blockquote-border);
+  color: var(--blockquote-text);
+  font-style: italic;
+}
+
+hr {
+  height: 1px;
+  background-color: var(--blockquote-border);
+  border: none; /* removes default border */
+}
+
+/* ============================================
+   Endnotes
+   ============================================ */
+section[role="doc-endnotes"] {
+  margin-top: 2em;
+  padding-top: 1em;
+  border-top: 1px solid var(--blockquote-border);
+}
+
+section[role="doc-endnotes"] ol li a[role="doc-backlink"] {
+  padding-right: 0.2em;
+}
+
+/* ============================================
+   Responsive
+   ============================================ */
+@media (max-width: 600px) {
+  body {
+    padding: 12px;
+    font-size: 0.9em;
+  }
+}
+</style></head>
+  <body>
+    <h2>Test</h2>
+    <p>Hello world.</p>
+  
+
+</body></html>

--- a/crates/tests/ref/examples/script_injection_no_css/html/index.js
+++ b/crates/tests/ref/examples/script_injection_no_css/html/index.js
@@ -1,0 +1,1 @@
+console.log("loaded");

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -1081,7 +1081,7 @@ fn test_asset_path_override_subdirectory() {
 
 /// Test that multiple [[html.assets]] blocks produce multiple stylesheet/script links in HTML.
 #[test]
-fn test_asset_multiple_blocks_default_combiner() {
+fn test_asset_multiple_blocks_inject_all() {
     let dir = tempfile::tempdir().expect("Failed to create temp dir");
     let project_path = dir.path();
 

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -862,6 +862,84 @@ fn test_asset_patterns_glob_recursive() {
     );
 }
 
+/// Test that `dest` on a [[html.assets]] block prefixes copy-glob outputs while
+/// preserving project-root-relative structure underneath.
+#[test]
+fn test_asset_patterns_dest_preserves_structure() {
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let project_path = dir.path();
+
+    // Single file + nested directory structure
+    std::fs::write(project_path.join("image.png"), b"\x89PNG\r\n\x1a\n")
+        .expect("Failed to write image.png");
+    let icons_dir = project_path.join("images/icons");
+    std::fs::create_dir_all(&icons_dir).expect("Failed to create images/icons dir");
+    std::fs::write(icons_dir.join("arrow.svg"), "<svg>arrow</svg>")
+        .expect("Failed to write images/icons/arrow.svg");
+
+    // Typst source
+    std::fs::write(project_path.join("main.typ"), "= Hello\n\nTest document.\n")
+        .expect("Failed to write main.typ");
+
+    // rheo.toml: one block with dest, one without
+    std::fs::write(
+        project_path.join("rheo.toml"),
+        format!(
+            "version = \"{}\"\n\
+             formats = [\"html\"]\n\
+             \n\
+             [[html.assets]]\n\
+             copy = [\"image.png\", \"images/**/*\"]\n\
+             dest = \"allassets\"\n\
+             \n\
+             [[html.assets]]\n\
+             copy = [\"main.typ\"]\n",
+            env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("Failed to write rheo.toml");
+
+    let build_dir = project_path.join("build");
+
+    let output = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "rheo",
+            "--",
+            "compile",
+            project_path.to_str().unwrap(),
+            "--html",
+            "--build-dir",
+            build_dir.to_str().unwrap(),
+        ])
+        .env("TYPST_IGNORE_SYSTEM_FONTS", "1")
+        .output()
+        .expect("Failed to run rheo compile");
+
+    assert!(
+        output.status.success(),
+        "Compilation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Block with dest = "allassets": structure preserved under dest prefix
+    assert!(
+        build_dir.join("html/allassets/image.png").exists(),
+        "image.png not found at html/allassets/image.png"
+    );
+    assert!(
+        build_dir.join("html/allassets/images/icons/arrow.svg").exists(),
+        "images/icons/arrow.svg not found at html/allassets/images/icons/arrow.svg"
+    );
+
+    // Block without dest: current behaviour (project-root-relative)
+    assert!(
+        build_dir.join("html/main.typ").exists(),
+        "main.typ not found at html/main.typ (block without dest)"
+    );
+}
+
 /// Test that `rheo init` creates a valid project that compiles successfully
 #[test]
 fn test_rheo_init_and_compile() {

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -25,6 +25,7 @@ use std::path::PathBuf;
 #[test_case("cases/pdf_individual")]
 #[test_case("cases/pdf_merge_false")]
 #[test_case("cases/script_injection")]
+#[test_case("cases/script_injection_no_css")]
 #[test_case("cases/relative_path_links")]
 #[test_case("cases/target_function")]
 #[test_case("cases/target_function_in_module")]

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -929,7 +929,9 @@ fn test_asset_patterns_dest_preserves_structure() {
         "image.png not found at html/allassets/image.png"
     );
     assert!(
-        build_dir.join("html/allassets/images/icons/arrow.svg").exists(),
+        build_dir
+            .join("html/allassets/images/icons/arrow.svg")
+            .exists(),
         "images/icons/arrow.svg not found at html/allassets/images/icons/arrow.svg"
     );
 
@@ -937,6 +939,86 @@ fn test_asset_patterns_dest_preserves_structure() {
     assert!(
         build_dir.join("html/main.typ").exists(),
         "main.typ not found at html/main.typ (block without dest)"
+    );
+}
+
+/// End-to-end test that `dest` works for both named assets and copy globs together.
+#[test]
+fn test_asset_dest_subdirectory() {
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let project_path = dir.path();
+
+    // Source files
+    std::fs::write(project_path.join("index.typ"), "= Hello\n\nWorld.\n").unwrap();
+    std::fs::write(project_path.join("image.png"), b"\x89PNG\r\n\x1a\n").unwrap();
+    std::fs::write(project_path.join("index.css"), "body { color: red; }").unwrap();
+    std::fs::create_dir_all(project_path.join("dist")).unwrap();
+    std::fs::write(project_path.join("dist/index.js"), "console.log(\"hi\");").unwrap();
+
+    std::fs::write(
+        project_path.join("rheo.toml"),
+        format!(
+            "version = \"{}\"\n\
+             formats = [\"html\"]\n\
+             \n\
+             [[html.assets]]\n\
+             dest = \"allassets\"\n\
+             copy = [\"image.png\"]\n\
+             js_scripts     = \"dist/index.js\"\n\
+             css_stylesheet = \"index.css\"\n",
+            env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .unwrap();
+
+    let build_dir = project_path.join("build");
+    let output = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "rheo",
+            "--",
+            "compile",
+            project_path.to_str().unwrap(),
+            "--html",
+            "--build-dir",
+            build_dir.to_str().unwrap(),
+        ])
+        .env("TYPST_IGNORE_SYSTEM_FONTS", "1")
+        .output()
+        .expect("Failed to run rheo compile");
+
+    assert!(
+        output.status.success(),
+        "Compilation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // All assets land under allassets/
+    assert!(
+        build_dir.join("html/allassets/image.png").is_file(),
+        "image.png not found at html/allassets/image.png"
+    );
+    assert!(
+        build_dir.join("html/allassets/index.css").is_file(),
+        "index.css not found at html/allassets/index.css"
+    );
+    assert!(
+        build_dir.join("html/allassets/index.js").is_file(),
+        "index.js not found at html/allassets/index.js (basename stripped from dist/index.js)"
+    );
+
+    // HTML output references the dest-prefixed paths
+    let html = std::fs::read_to_string(build_dir.join("html/index.html")).unwrap();
+    assert!(
+        html.contains("allassets/index.css"),
+        "html should link stylesheet at allassets/index.css:\n{}",
+        html
+    );
+    assert!(
+        html.contains("allassets/index.js"),
+        "html should reference script at allassets/index.js:\n{}",
+        html
     );
 }
 

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -716,6 +716,81 @@ fn test_asset_patterns() {
     );
 }
 
+/// Test that `**/*` glob patterns recursively copy nested files into the build output.
+#[test]
+fn test_asset_patterns_glob_recursive() {
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let project_path = dir.path();
+
+    // Create nested directory structure
+    let icons_dir = project_path.join("images/icons");
+    std::fs::create_dir_all(&icons_dir).expect("Failed to create images/icons dir");
+    std::fs::write(project_path.join("images/hero.png"), b"\x89PNG\r\n\x1a\n")
+        .expect("Failed to write images/hero.png");
+    std::fs::write(icons_dir.join("arrow.svg"), "<svg>arrow</svg>")
+        .expect("Failed to write images/icons/arrow.svg");
+
+    // Typst source
+    std::fs::write(project_path.join("main.typ"), "= Hello\n\nTest document.\n")
+        .expect("Failed to write main.typ");
+
+    // rheo.toml with recursive glob pattern
+    std::fs::write(
+        project_path.join("rheo.toml"),
+        format!(
+            "version = \"{}\"\n\
+             formats = [\"html\"]\n\
+             \n\
+             [html.assets]\n\
+             copy = [\"images/**/*\"]\n",
+            env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("Failed to write rheo.toml");
+
+    let build_dir = project_path.join("build");
+
+    let output = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "rheo",
+            "--",
+            "compile",
+            project_path.to_str().unwrap(),
+            "--html",
+            "--build-dir",
+            build_dir.to_str().unwrap(),
+        ])
+        .env("TYPST_IGNORE_SYSTEM_FONTS", "1")
+        .output()
+        .expect("Failed to run rheo compile");
+
+    assert!(
+        output.status.success(),
+        "Compilation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Both nested files should be copied, preserving directory structure
+    let html_hero = build_dir.join("html/images/hero.png");
+    assert!(
+        html_hero.exists(),
+        "Recursive glob: images/hero.png not found in html output"
+    );
+
+    let html_arrow = build_dir.join("html/images/icons/arrow.svg");
+    assert!(
+        html_arrow.exists(),
+        "Recursive glob: images/icons/arrow.svg not found in html output"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&html_arrow).unwrap(),
+        "<svg>arrow</svg>",
+        "Copied arrow.svg has wrong content"
+    );
+}
+
 /// Test that `rheo init` creates a valid project that compiles successfully
 #[test]
 fn test_rheo_init_and_compile() {

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -1110,10 +1110,15 @@ fn test_asset_multiple_blocks_default_combiner() {
     let build_dir = project_path.join("build");
     let output = std::process::Command::new("cargo")
         .args([
-            "run", "-p", "rheo", "--",
-            "compile", project_path.to_str().unwrap(),
+            "run",
+            "-p",
+            "rheo",
+            "--",
+            "compile",
+            project_path.to_str().unwrap(),
             "--html",
-            "--build-dir", build_dir.to_str().unwrap(),
+            "--build-dir",
+            build_dir.to_str().unwrap(),
         ])
         .env("TYPST_IGNORE_SYSTEM_FONTS", "1")
         .output()
@@ -1126,15 +1131,10 @@ fn test_asset_multiple_blocks_default_combiner() {
     );
 
     for f in ["one.css", "two.css", "one.js", "two.js"] {
-        assert!(
-            build_dir.join("html").join(f).exists(),
-            "missing {}",
-            f
-        );
+        assert!(build_dir.join("html").join(f).exists(), "missing {}", f);
     }
 
-    let html =
-        std::fs::read_to_string(build_dir.join("html/hello.html")).unwrap();
+    let html = std::fs::read_to_string(build_dir.join("html/hello.html")).unwrap();
     assert!(
         html.contains("one.css") && html.contains("two.css"),
         "html should link both stylesheets:\n{}",

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -1079,6 +1079,74 @@ fn test_asset_path_override_subdirectory() {
     );
 }
 
+/// Test that multiple [[html.assets]] blocks produce multiple stylesheet/script links in HTML.
+#[test]
+fn test_asset_multiple_blocks_default_combiner() {
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let project_path = dir.path();
+
+    std::fs::write(project_path.join("one.css"), "/* one */").unwrap();
+    std::fs::write(project_path.join("two.css"), "/* two */").unwrap();
+    std::fs::write(project_path.join("one.js"), "// one").unwrap();
+    std::fs::write(project_path.join("two.js"), "// two").unwrap();
+    std::fs::write(project_path.join("hello.typ"), "Hello").unwrap();
+
+    std::fs::write(
+        project_path.join("rheo.toml"),
+        format!(
+            "version = \"{}\"\n\
+             formats = [\"html\"]\n\
+             [[html.assets]]\n\
+             css_stylesheet = \"one.css\"\n\
+             js_scripts     = \"one.js\"\n\
+             [[html.assets]]\n\
+             css_stylesheet = \"two.css\"\n\
+             js_scripts     = \"two.js\"\n",
+            env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .unwrap();
+
+    let build_dir = project_path.join("build");
+    let output = std::process::Command::new("cargo")
+        .args([
+            "run", "-p", "rheo", "--",
+            "compile", project_path.to_str().unwrap(),
+            "--html",
+            "--build-dir", build_dir.to_str().unwrap(),
+        ])
+        .env("TYPST_IGNORE_SYSTEM_FONTS", "1")
+        .output()
+        .expect("Failed to run rheo compile");
+
+    assert!(
+        output.status.success(),
+        "Compilation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for f in ["one.css", "two.css", "one.js", "two.js"] {
+        assert!(
+            build_dir.join("html").join(f).exists(),
+            "missing {}",
+            f
+        );
+    }
+
+    let html =
+        std::fs::read_to_string(build_dir.join("html/hello.html")).unwrap();
+    assert!(
+        html.contains("one.css") && html.contains("two.css"),
+        "html should link both stylesheets:\n{}",
+        html
+    );
+    assert!(
+        html.contains("one.js") && html.contains("two.js"),
+        "html should reference both scripts:\n{}",
+        html
+    );
+}
+
 /// Test that a merged spine with a missing relative import produces a clear error
 /// referencing the original source file path (not a temp path).
 #[test]

--- a/crates/tests/tests/harness.rs
+++ b/crates/tests/tests/harness.rs
@@ -716,6 +716,76 @@ fn test_asset_patterns() {
     );
 }
 
+/// Test that copy globs across multiple [[html.assets]] blocks are all collected.
+#[test]
+fn test_asset_patterns_multiple_blocks() {
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let project_path = dir.path();
+
+    // Source files to copy from two different directories
+    std::fs::create_dir_all(project_path.join("css")).expect("Failed to create css dir");
+    std::fs::write(project_path.join("css/theme.css"), "body {}")
+        .expect("Failed to write css/theme.css");
+    std::fs::create_dir_all(project_path.join("js")).expect("Failed to create js dir");
+    std::fs::write(project_path.join("js/app.js"), "console.log(1)")
+        .expect("Failed to write js/app.js");
+
+    // Typst source
+    std::fs::write(project_path.join("main.typ"), "= Hello\n\nTest document.\n")
+        .expect("Failed to write main.typ");
+
+    // rheo.toml: two [[html.assets]] blocks each with their own copy patterns
+    std::fs::write(
+        project_path.join("rheo.toml"),
+        format!(
+            "version = \"{}\"\n\
+             formats = [\"html\"]\n\
+             \n\
+             [[html.assets]]\n\
+             copy = [\"css/**/*\"]\n\
+             \n\
+             [[html.assets]]\n\
+             copy = [\"js/**/*\"]\n",
+            env!("CARGO_PKG_VERSION"),
+        ),
+    )
+    .expect("Failed to write rheo.toml");
+
+    let build_dir = project_path.join("build");
+
+    let output = std::process::Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "rheo",
+            "--",
+            "compile",
+            project_path.to_str().unwrap(),
+            "--html",
+            "--build-dir",
+            build_dir.to_str().unwrap(),
+        ])
+        .env("TYPST_IGNORE_SYSTEM_FONTS", "1")
+        .output()
+        .expect("Failed to run rheo compile");
+
+    assert!(
+        output.status.success(),
+        "Compilation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Both blocks' copy patterns should produce files in html output
+    assert!(
+        build_dir.join("html/css/theme.css").exists(),
+        "css/theme.css not found in html output"
+    );
+    assert!(
+        build_dir.join("html/js/app.js").exists(),
+        "js/app.js not found in html output"
+    );
+}
+
 /// Test that `**/*` glob patterns recursively copy nested files into the build output.
 #[test]
 fn test_asset_patterns_glob_recursive() {

--- a/examples/slides_html_pdf/rheo-slides/src/lib.ts
+++ b/examples/slides_html_pdf/rheo-slides/src/lib.ts
@@ -3,8 +3,6 @@
 import Reveal from 'reveal.js';
 import revealCss from 'reveal.js/dist/reveal.css?raw';
 import themeCss from 'reveal.js/dist/theme/white.css?raw';
-import myStyle from './style.css?raw'; // Import your CSS as string
-
 const style = document.createElement('style');
 style.textContent = revealCss + themeCss;
 document.head.appendChild(style);

--- a/examples/slides_html_pdf/rheo-slides/src/lib.ts
+++ b/examples/slides_html_pdf/rheo-slides/src/lib.ts
@@ -3,6 +3,7 @@
 import Reveal from 'reveal.js';
 import revealCss from 'reveal.js/dist/reveal.css?raw';
 import themeCss from 'reveal.js/dist/theme/white.css?raw';
+import myStyle from './style.css?raw'; // Import your CSS as string
 
 const style = document.createElement('style');
 style.textContent = revealCss + themeCss;


### PR DESCRIPTION
In service of allowing packages, which will essentially be syntactic sugar for a set of associated assets, this PR enables assets to be specified using TOML arrays of objects. Multiple sets of assets can now be specified for each `FormatPlugin`, and a `dest` can be specified so that each set can end up in its own folder:

```toml
[[html.assets]]
dest = "set1"
copy = ["image.png"]
js_scripts = "index.js"
css_stylesheets = "index.css"

[[html.assets]]
dest = "set2"
js_scripts = "anotherfile.js"
css_stylesheets = "anotherfile.css"
```

It also updates the html FormatPlugin's `compile` logic so that, when multiple asset sets are specified, the multiple `js_scripts` files are injected via multiple `<script>` tags into the HTML head, as are multiple `css_stylesheet` files via `<link>` tags.