### PR TITLE
Distinguish EPUB from HTML in target()

### DIFF
--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -186,8 +186,12 @@ impl Build {
 
         let spine_source = virtual_spine.source();
 
-        let world =
-            RheoWorld::new_for_bundle(&self.project.root, spine_source, self.font_dirs.clone())?;
+        let world = RheoWorld::new_for_bundle(
+            &self.project.root,
+            spine_source,
+            html_plugin.rheo_target(),
+            self.font_dirs.clone(),
+        )?;
         let bundle = world.compile_bundle()?;
         let virtual_fs = export_bundle(&bundle)?;
 
@@ -317,6 +321,7 @@ impl Build {
             let world = RheoWorld::new_for_bundle(
                 &self.project.root,
                 spine_source,
+                plugin.rheo_target(),
                 self.font_dirs.clone(),
             )?;
             let bundle = world.compile_bundle()?;

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -269,6 +269,20 @@ pub trait FormatPlugin: Send + Sync {
         TypstFormat::Html
     }
 
+    /// The value injected as `sys.inputs.rheo-target`, surfaced to documents via
+    /// the `target()` polyfill.
+    ///
+    /// This keeps formats that share a Typst export target distinguishable: EPUB
+    /// and HTML both compile via the `html` target, but report `"epub"` and
+    /// `"html"` respectively, so packages can branch on the rheo output format.
+    ///
+    /// Returning `None` injects nothing, leaving `target()` to fall back to
+    /// Typst's `std.target()` — used by PDF, which wants the native `"paged"`.
+    /// Defaults to `Some(name())`.
+    fn rheo_target(&self) -> Option<&'static str> {
+        Some(self.name())
+    }
+
     /// Set plugin-specific smart defaults when no rheo.toml section exists.
     fn apply_defaults(&self, _section: &mut PluginSection, _project_name: &str) {}
 

--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -103,6 +103,7 @@ impl RheoWorld {
     pub fn new_for_bundle(
         root: &Path,
         virtual_main_source: String,
+        format_name: Option<&str>,
         font_dirs: Vec<PathBuf>,
     ) -> Result<Self> {
         let root = crate::path_utils::canonicalize_path(root)?;
@@ -114,6 +115,7 @@ impl RheoWorld {
 
         let library = Library::builder()
             .with_features([Feature::Html, Feature::Bundle].into_iter().collect())
+            .with_inputs(build_inputs(format_name))
             .build();
 
         let (font_store, package_storage, rheo_packages) = Self::init_resources(&font_dirs);
@@ -127,7 +129,7 @@ impl RheoWorld {
             package_storage,
             rheo_packages,
             slots: Mutex::new(HashMap::new()),
-            format_name: None,
+            format_name: format_name.map(str::to_string),
             plugin_library: None,
             virtual_main_source: Some(virtual_main_source),
         })

--- a/crates/pdf/src/lib.rs
+++ b/crates/pdf/src/lib.rs
@@ -19,6 +19,12 @@ impl FormatPlugin for PdfPlugin {
         TypstFormat::Pdf
     }
 
+    /// PDF compiles to the paged target; leave `target()` as Typst's native
+    /// `"paged"` rather than injecting a rheo override.
+    fn rheo_target(&self) -> Option<&'static str> {
+        None
+    }
+
     fn format_init_template(&self) -> FormatInitTemplate {
         FormatInitTemplate {
             files: vec![],


### PR DESCRIPTION
The `target()` polyfill exposes rheo's output format to documents via `sys.inputs.rheo-target`. The bundle compile path (`new_for_bundle`) never set that input, so `target()` fell back to Typst's `std.target()`. EPUB compiles via the `html` target, so `std.target()` returned `"html"` for both HTML and EPUB — leaving packages (e.g. sidebar) unable to tell them apart.

- Adds `FormatPlugin::rheo_target()` (default `Some(name())`; PDF returns `None` to keep the native `"paged"`).
- Threads it into `new_for_bundle` and injects it as `sys.inputs.rheo-target`.
- `target()` now reports `"html"`, `"epub"`, and `"paged"` per format.