### PR TITLE
QoL improvments for the `watch` server

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cargo install --locked rheo
 # Or build from source
 git clone https://github.com/freecomputinglab/rheo
 cd rheo
-cargo install --path .
+cargo install --path crates/cli
 ```
 
 ### Using Nix flakes

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -457,65 +457,73 @@ fn run_watch(sub: &ArgMatches) -> Result<()> {
         .base
         .canonicalize()
         .unwrap_or_else(|_| build.output_config().base.clone());
+    // Capture the asset sources to watch (declared assets, copy globs, package
+    // roots) once, before `build` is moved into the change callback.
+    let asset_spec = build.watch_asset_spec();
 
-    watch_project(&watch_project_cfg, &build_dir_canonical, move |event| {
-        match event {
-            WatchEvent::FilesChanged => {
-                info!("files changed, recompiling");
-                if build.run().is_ok() {
-                    // Update HTML dev server VirtualFs before triggering browser reload.
-                    for handle in &open_handles {
-                        if let OpenHandle::Server(server) = handle {
-                            match build.compile_for_watch() {
-                                Ok(Some(vfs)) => {
-                                    let t = std::time::Instant::now();
-                                    server.update_virtual_fs(vfs);
-                                    debug!(ms = t.elapsed().as_millis(), "VirtualFs updated");
-                                }
-                                Ok(None) => {}
-                                Err(e) => {
-                                    warn!(error = %e, "VirtualFs compile failed, reload will serve stale content")
-                                }
-                            }
-                            server.reload();
-                            break; // only one server handle expected
-                        }
-                    }
-                }
-            }
-            WatchEvent::ConfigChanged => {
-                info!("config changed, reloading");
-                match prepare_build(
-                    &path,
-                    config_path.as_deref(),
-                    build_dir.clone(),
-                    enabled.clone(),
-                    cli_font_dirs.clone(),
-                ) {
-                    Ok(new_build) => {
-                        build = new_build;
-                        if build.run().is_ok() {
-                            for handle in &open_handles {
-                                if let OpenHandle::Server(server) = handle {
-                                    match build.compile_for_watch() {
-                                        Ok(Some(vfs)) => server.update_virtual_fs(vfs),
-                                        Ok(None) => {}
-                                        Err(e) => {
-                                            warn!(error = %e, "VirtualFs compile failed after config reload")
-                                        }
+    watch_project(
+        &watch_project_cfg,
+        &build_dir_canonical,
+        &asset_spec,
+        move |event| {
+            match event {
+                WatchEvent::FilesChanged => {
+                    info!("files changed, recompiling");
+                    if build.run().is_ok() {
+                        // Update HTML dev server VirtualFs before triggering browser reload.
+                        for handle in &open_handles {
+                            if let OpenHandle::Server(server) = handle {
+                                match build.compile_for_watch() {
+                                    Ok(Some(vfs)) => {
+                                        let t = std::time::Instant::now();
+                                        server.update_virtual_fs(vfs);
+                                        debug!(ms = t.elapsed().as_millis(), "VirtualFs updated");
                                     }
-                                    server.reload();
-                                    break;
+                                    Ok(None) => {}
+                                    Err(e) => {
+                                        warn!(error = %e, "VirtualFs compile failed, reload will serve stale content")
+                                    }
                                 }
+                                server.reload();
+                                break; // only one server handle expected
                             }
                         }
                     }
-                    Err(e) => warn!(error = %e, "failed to reload config"),
+                }
+                WatchEvent::ConfigChanged => {
+                    info!("config changed, reloading");
+                    match prepare_build(
+                        &path,
+                        config_path.as_deref(),
+                        build_dir.clone(),
+                        enabled.clone(),
+                        cli_font_dirs.clone(),
+                    ) {
+                        Ok(new_build) => {
+                            build = new_build;
+                            if build.run().is_ok() {
+                                for handle in &open_handles {
+                                    if let OpenHandle::Server(server) = handle {
+                                        match build.compile_for_watch() {
+                                            Ok(Some(vfs)) => server.update_virtual_fs(vfs),
+                                            Ok(None) => {}
+                                            Err(e) => {
+                                                warn!(error = %e, "VirtualFs compile failed after config reload")
+                                            }
+                                        }
+                                        server.reload();
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => warn!(error = %e, "failed to reload config"),
+                    }
                 }
             }
-        }
-        Ok(())
-    })
+            Ok(())
+        },
+    )
 }
 
 fn run_compile(sub: &ArgMatches) -> Result<()> {

--- a/crates/core/src/assets.rs
+++ b/crates/core/src/assets.rs
@@ -171,6 +171,7 @@ impl<'a> AssetResolver<'a> {
                         seen_relative_paths.insert(rel.clone(), src.clone());
                         Ok(Asset {
                             config: asset_config.clone(),
+                            source_path: src.clone(),
                             resolved_path: abs,
                             built_relative_path: rel,
                         })

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -95,6 +95,71 @@ impl Build {
         &self.output
     }
 
+    /// Derive the set of asset sources the watcher should treat as relevant.
+    ///
+    /// Mirrors the asset-resolution pass in [`run`](Self::run) across every
+    /// enabled plugin — collecting each resolved asset's source path, the
+    /// project/plugin/package `copy` glob patterns, and the source roots of any
+    /// packages that declare assets — so watch coverage is driven by what the
+    /// plugins actually declare rather than a hard-coded extension list.
+    ///
+    /// Only packages that declare rheo assets in their `typst.toml` contribute a
+    /// source root here, so the watched set stays tight (immutable `@preview`
+    /// deps that declare nothing are never watched).
+    pub fn watch_asset_spec(&self) -> crate::watch::WatchAssetSpec {
+        let default_section = PluginSection::default();
+        let package_imports = crate::plugins::scan_project_package_imports(&self.project.typ_files);
+
+        let mut asset_paths: Vec<PathBuf> = Vec::new();
+        let mut copy_globs: Vec<(PathBuf, Vec<String>)> = Vec::new();
+        let mut package_roots: Vec<PathBuf> = Vec::new();
+
+        for plugin in &self.plugins {
+            let plugin_output_dir = self.output.dir_for_plugin(plugin.name());
+            let plugin_section: &PluginSection = self
+                .project
+                .config
+                .plugin_sections
+                .get(plugin.name())
+                .unwrap_or(&default_section);
+
+            let manifest_blocks = if plugin_section.auto_detect_packages_enabled() {
+                crate::plugins::detect_manifest_package_assets(&package_imports, plugin.name())
+            } else {
+                vec![]
+            };
+
+            let resolver = AssetResolver::new(&self.project.root, &plugin_output_dir);
+            if let Ok(resolved) =
+                resolver.resolve(plugin.as_ref(), plugin_section, &manifest_blocks)
+            {
+                for assets in resolved.values() {
+                    for asset in assets {
+                        asset_paths.push(asset.source_path.clone());
+                    }
+                }
+            }
+
+            // Copy globs: project-level, per-package, and per-plugin asset blocks.
+            if !self.project.config.copy.is_empty() {
+                copy_globs.push((self.project.root.clone(), self.project.config.copy.clone()));
+            }
+            for block in &manifest_blocks {
+                if !block.assets.copy.is_empty() {
+                    copy_globs.push((block.source_root.clone(), block.assets.copy.clone()));
+                }
+                package_roots.push(block.source_root.clone());
+            }
+            for block in plugin_section.asset_blocks() {
+                if !block.copy.is_empty() {
+                    copy_globs.push((self.project.root.clone(), block.copy.clone()));
+                }
+            }
+        }
+
+        crate::watch::WatchAssetSpec::new(asset_paths, copy_globs, package_roots)
+    }
+
     /// Compile HTML to an in-memory VirtualFs for the dev server.
     ///
     /// Resolves assets (CSS/JS), copies them to the plugin output dir so the

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -55,6 +55,12 @@ pub struct AssetConfig {
 #[derive(Debug, Clone)]
 pub struct Asset {
     pub config: AssetConfig,
+    /// Absolute path of the source file this asset was copied from.
+    ///
+    /// For user-declared assets this is under the project root; for
+    /// package-declared assets it is under the package's `source_root`.
+    pub source_path: PathBuf,
+    /// Absolute path of the copied file in the plugin output directory.
     pub resolved_path: PathBuf,
     pub built_relative_path: String,
 }

--- a/crates/core/src/watch.rs
+++ b/crates/core/src/watch.rs
@@ -21,7 +21,7 @@ pub enum WatchEvent {
 ///
 /// This function sets up file system watching for:
 /// - All .typ files in the project
-/// - Asset files (style.css)
+/// - Assets declared by the format plugins (any filename, any subdirectory)
 /// - Project configuration (rheo.toml)
 ///
 /// Changes are debounced with a 1-second delay to avoid rapid rebuilds during editing.
@@ -176,7 +176,7 @@ fn is_relevant_path(path: &Path, project: &ProjectConfig, build_dir: &Path) -> b
 
     match project.mode {
         ProjectMode::SingleFile => {
-            // Only the exact file is relevant (and assets in parent directory)
+            // Only the exact file is relevant (and CSS/JS assets in parent directory)
             let target_file = &project.typ_files[0];
 
             // Check if it's the specific .typ file
@@ -184,11 +184,8 @@ fn is_relevant_path(path: &Path, project: &ProjectConfig, build_dir: &Path) -> b
                 return true;
             }
 
-            // Check if it's style.css in the same directory
-            if path.file_name().and_then(|n| n.to_str()) == Some("style.css")
-                && let Some(parent) = path.parent()
-                && parent == project.root
-            {
+            // Check if it's a plugin-declared asset (any filename, in the watched directory)
+            if is_asset_path(path) {
                 return true;
             }
 
@@ -206,14 +203,9 @@ fn is_relevant_path(path: &Path, project: &ProjectConfig, build_dir: &Path) -> b
                 return true;
             }
 
-            // Check if it's style.css
-            if path.file_name().and_then(|n| n.to_str()) == Some("style.css") {
-                // Only if it's in the project root
-                if let Some(parent) = path.parent()
-                    && parent == project.root
-                {
-                    return true;
-                }
+            // Check if it's a plugin-declared asset (any filename, any subdirectory)
+            if is_asset_path(path) {
+                return true;
             }
 
             // Check if it's a font file
@@ -229,5 +221,80 @@ fn is_relevant_path(path: &Path, project: &ProjectConfig, build_dir: &Path) -> b
 
             false
         }
+    }
+}
+
+/// Check if a path is an asset declared through the `FormatPlugin::assets`
+/// mechanism (e.g. the HTML plugin's `css_stylesheet` and `js_scripts`).
+///
+/// Matches by extension (not filename) so custom stylesheets, `index.js`,
+/// and assets in subdirectories all trigger rebuilds. The declared asset
+/// kinds are currently CSS and JS across all plugins; extend this set if a
+/// plugin declares assets with other extensions. Callers must have already
+/// excluded the build directory to avoid rebuild loops.
+fn is_asset_path(path: &Path) -> bool {
+    let asset_extensions = ["css", "js"];
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| asset_extensions.contains(&e))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Build a directory-mode project rooted at `temp` with one .typ file.
+    fn dir_project(temp: &TempDir) -> ProjectConfig {
+        fs::write(temp.path().join("doc.typ"), "#heading[Test]").unwrap();
+        ProjectConfig::from_path(temp.path(), None).unwrap()
+    }
+
+    #[test]
+    fn test_css_in_subdirectory_is_relevant() {
+        let temp = TempDir::new().unwrap();
+        let project = dir_project(&temp);
+        let build_dir = project.root.join("build");
+
+        let css = project.root.join("styles").join("custom.css");
+        assert!(is_relevant_path(&css, &project, &build_dir));
+    }
+
+    #[test]
+    fn test_js_asset_is_relevant() {
+        let temp = TempDir::new().unwrap();
+        let project = dir_project(&temp);
+        let build_dir = project.root.join("build");
+
+        let js = project.root.join("index.js");
+        assert!(is_relevant_path(&js, &project, &build_dir));
+    }
+
+    #[test]
+    fn test_css_under_build_dir_is_excluded() {
+        let temp = TempDir::new().unwrap();
+        let project = dir_project(&temp);
+        let build_dir = project.root.join("build");
+        fs::create_dir_all(&build_dir).unwrap();
+
+        // File must exist so canonicalize-based exclusion applies.
+        let generated = build_dir.join("style.css");
+        fs::write(&generated, "body {}").unwrap();
+
+        assert!(!is_relevant_path(&generated, &project, &build_dir));
+    }
+
+    #[test]
+    fn test_single_file_css_asset_is_relevant() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("document.typ");
+        fs::write(&file, "#heading[Test]").unwrap();
+        let project = ProjectConfig::from_path(&file, None).unwrap();
+        let build_dir = project.root.join("build");
+
+        let css = project.root.join("custom.css");
+        assert!(is_relevant_path(&css, &project, &build_dir));
     }
 }

--- a/crates/core/src/watch.rs
+++ b/crates/core/src/watch.rs
@@ -2,11 +2,106 @@ use crate::{
     Result,
     project::{ProjectConfig, ProjectMode},
 };
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::channel;
 use std::time::Duration;
 use tracing::{debug, info, warn};
+
+/// The set of asset sources a build depends on, used by the watcher to decide
+/// which changed files are relevant — independent of file extension.
+///
+/// This is derived from what the format plugins actually declare through the
+/// [`FormatPlugin::assets`](crate::FormatPlugin::assets) mechanism (plus
+/// project/plugin/package `copy` globs), so watch coverage tracks whatever each
+/// plugin — or an imported Typst package — contributes, without hard-coding any
+/// extension. Build it with [`crate::Build::watch_asset_spec`].
+#[derive(Debug, Default)]
+pub struct WatchAssetSpec {
+    /// Absolute (canonicalized where possible) source paths of every resolved
+    /// asset across all enabled plugins.
+    asset_paths: HashSet<PathBuf>,
+    /// Compiled glob set matching copy-pattern sources (absolute patterns).
+    copy_globs: Option<GlobSet>,
+    /// Package `source_root` directories that must be watched in addition to the
+    /// project root, since package assets live outside the project tree.
+    package_roots: Vec<PathBuf>,
+}
+
+impl WatchAssetSpec {
+    /// Assemble a spec from resolved asset source paths, `(base, patterns)` copy
+    /// globs, and package source roots. Asset paths and glob bases are
+    /// canonicalized where possible so they compare equal to the (canonicalized)
+    /// paths reported by the filesystem watcher.
+    pub fn new(
+        asset_paths: Vec<PathBuf>,
+        copy_globs: Vec<(PathBuf, Vec<String>)>,
+        mut package_roots: Vec<PathBuf>,
+    ) -> Self {
+        let asset_paths = asset_paths
+            .into_iter()
+            .map(|p| p.canonicalize().unwrap_or(p))
+            .collect();
+
+        let mut builder = GlobSetBuilder::new();
+        let mut any_glob = false;
+        for (base, patterns) in &copy_globs {
+            let base = base.canonicalize().unwrap_or_else(|_| base.clone());
+            for pattern in patterns {
+                if let Some(abs) = base.join(pattern).to_str()
+                    && let Ok(glob) = Glob::new(abs)
+                {
+                    builder.add(glob);
+                    any_glob = true;
+                }
+            }
+        }
+        let copy_globs = if any_glob { builder.build().ok() } else { None };
+
+        package_roots = package_roots
+            .into_iter()
+            .map(|p| p.canonicalize().unwrap_or(p))
+            .collect();
+        package_roots.sort();
+        package_roots.dedup();
+
+        Self {
+            asset_paths,
+            copy_globs,
+            package_roots,
+        }
+    }
+
+    /// Directories outside the project root that must also be watched.
+    pub fn package_roots(&self) -> &[PathBuf] {
+        &self.package_roots
+    }
+
+    /// True if `path` is one of the resolved asset sources or matches a copy glob.
+    fn matches(&self, path: &Path) -> bool {
+        let canonical = path.canonicalize().ok();
+        if self.asset_paths.contains(path)
+            || canonical
+                .as_deref()
+                .is_some_and(|c| self.asset_paths.contains(c))
+        {
+            return true;
+        }
+        if let Some(set) = &self.copy_globs {
+            if set.is_match(path) {
+                return true;
+            }
+            if let Some(c) = &canonical
+                && set.is_match(c)
+            {
+                return true;
+            }
+        }
+        false
+    }
+}
 
 /// Event indicating files have changed and compilation should be triggered
 #[derive(Debug)]
@@ -21,20 +116,32 @@ pub enum WatchEvent {
 ///
 /// This function sets up file system watching for:
 /// - All .typ files in the project
-/// - Assets declared by the format plugins (any filename, any subdirectory)
+/// - Assets declared by the format plugins or imported packages (any filename,
+///   any subdirectory, any extension — see [`WatchAssetSpec`])
 /// - Project configuration (rheo.toml)
 ///
 /// Changes are debounced with a 1-second delay to avoid rapid rebuilds during editing.
 ///
+/// The asset spec is captured once at startup. A `rheo.toml` change triggers a
+/// full reload but does not re-derive the spec, so a project that adds a brand
+/// new asset or package mid-session may need the watch to be restarted before
+/// edits to those new files are picked up.
+///
 /// # Arguments
 /// * `project` - Project configuration with source files
 /// * `build_dir` - Canonicalized build directory path to exclude from watching
+/// * `asset_spec` - Resolved asset sources / package roots to treat as relevant
 /// * `callback` - Function called when files change, receives WatchEvent
 ///
 /// # Returns
 /// * `Ok(())` when watching stops gracefully (e.g., Ctrl+C)
 /// * `Err` if watcher setup fails
-pub fn watch_project<F>(project: &ProjectConfig, build_dir: &Path, mut callback: F) -> Result<()>
+pub fn watch_project<F>(
+    project: &ProjectConfig,
+    build_dir: &Path,
+    asset_spec: &WatchAssetSpec,
+    mut callback: F,
+) -> Result<()>
 where
     F: FnMut(WatchEvent) -> Result<()>,
 {
@@ -70,6 +177,19 @@ where
         }
     }
 
+    // Watch each package source root (outside the project tree) so edits to
+    // package-declared assets also trigger rebuilds. A failure here is not fatal:
+    // the package cache may be read-only or large, and the rest of the watch
+    // should still work.
+    for root in asset_spec.package_roots() {
+        match watcher.watch(root, RecursiveMode::Recursive) {
+            Ok(()) => debug!(path = %root.display(), "watching package asset root"),
+            Err(e) => {
+                warn!(error = %e, path = %root.display(), "failed to watch package asset root")
+            }
+        }
+    }
+
     // Debounce logic: collect events for 1 second before triggering recompilation
     // This prevents excessive recompilation when editors save multiple files rapidly
     // or when a single edit triggers multiple filesystem events
@@ -98,7 +218,7 @@ where
                         let paths: Vec<PathBuf> = event
                             .paths
                             .into_iter()
-                            .filter(|p| is_relevant_path(p, project, build_dir))
+                            .filter(|p| is_relevant_path(p, project, build_dir, asset_spec))
                             .collect();
 
                         if !paths.is_empty() {
@@ -160,7 +280,12 @@ where
 }
 
 /// Check if a path is relevant for triggering recompilation
-fn is_relevant_path(path: &Path, project: &ProjectConfig, build_dir: &Path) -> bool {
+fn is_relevant_path(
+    path: &Path,
+    project: &ProjectConfig,
+    build_dir: &Path,
+    asset_spec: &WatchAssetSpec,
+) -> bool {
     // CRITICAL: Exclude all paths under the build directory to prevent infinite loops
     // Try canonicalized comparison first (handles symlinks and relative paths)
     if let Ok(canonical_path) = path.canonicalize() {
@@ -174,26 +299,20 @@ fn is_relevant_path(path: &Path, project: &ProjectConfig, build_dir: &Path) -> b
         return false;
     }
 
+    // A declared/resolved asset (from any plugin or imported package) or a
+    // copy-glob match is relevant regardless of extension or location. This
+    // covers both project-local assets and package assets under a package root.
+    if asset_spec.matches(path) {
+        return true;
+    }
+
     match project.mode {
         ProjectMode::SingleFile => {
-            // Only the exact file is relevant (and CSS/JS assets in parent directory)
-            let target_file = &project.typ_files[0];
-
-            // Check if it's the specific .typ file
-            if path == target_file {
-                return true;
-            }
-
-            // Check if it's a plugin-declared asset (any filename, in the watched directory)
-            if is_asset_path(path) {
-                return true;
-            }
-
-            false
+            // Otherwise only the exact target .typ file is relevant.
+            path == project.typ_files[0].as_path()
         }
         ProjectMode::Directory => {
-            // Existing logic for directory mode
-            // Check if it's a .typ file
+            // Any .typ file in the project triggers recompilation.
             if path.extension().and_then(|e| e.to_str()) == Some("typ") {
                 return true;
             }
@@ -203,41 +322,14 @@ fn is_relevant_path(path: &Path, project: &ProjectConfig, build_dir: &Path) -> b
                 return true;
             }
 
-            // Check if it's a plugin-declared asset (any filename, any subdirectory)
-            if is_asset_path(path) {
-                return true;
-            }
-
             // Check if it's a font file
             let font_extensions = ["ttf", "otf", "woff", "woff2"];
-            if path
-                .extension()
+            path.extension()
                 .and_then(|e| e.to_str())
                 .map(|e| font_extensions.contains(&e))
                 .unwrap_or(false)
-            {
-                return true;
-            }
-
-            false
         }
     }
-}
-
-/// Check if a path is an asset declared through the `FormatPlugin::assets`
-/// mechanism (e.g. the HTML plugin's `css_stylesheet` and `js_scripts`).
-///
-/// Matches by extension (not filename) so custom stylesheets, `index.js`,
-/// and assets in subdirectories all trigger rebuilds. The declared asset
-/// kinds are currently CSS and JS across all plugins; extend this set if a
-/// plugin declares assets with other extensions. Callers must have already
-/// excluded the build directory to avoid rebuild loops.
-fn is_asset_path(path: &Path) -> bool {
-    let asset_extensions = ["css", "js"];
-    path.extension()
-        .and_then(|e| e.to_str())
-        .map(|e| asset_extensions.contains(&e))
-        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -252,42 +344,98 @@ mod tests {
         ProjectConfig::from_path(temp.path(), None).unwrap()
     }
 
+    fn empty_spec() -> WatchAssetSpec {
+        WatchAssetSpec::default()
+    }
+
     #[test]
-    fn test_css_in_subdirectory_is_relevant() {
+    fn test_declared_asset_with_any_extension_is_relevant() {
         let temp = TempDir::new().unwrap();
         let project = dir_project(&temp);
         let build_dir = project.root.join("build");
 
-        let css = project.root.join("styles").join("custom.css");
-        assert!(is_relevant_path(&css, &project, &build_dir));
+        // A plugin might declare an asset with any extension — here .scss in a
+        // subdirectory. The watcher must treat it as relevant purely because it
+        // is a declared source, not because of its extension.
+        let scss = project.root.join("styles").join("theme.scss");
+        let spec = WatchAssetSpec::new(vec![scss.clone()], vec![], vec![]);
+
+        assert!(is_relevant_path(&scss, &project, &build_dir, &spec));
+        // An undeclared file with the same unusual extension is NOT relevant.
+        let other = project.root.join("styles").join("other.scss");
+        assert!(!is_relevant_path(&other, &project, &build_dir, &spec));
     }
 
     #[test]
-    fn test_js_asset_is_relevant() {
+    fn test_copy_glob_match_is_relevant() {
         let temp = TempDir::new().unwrap();
         let project = dir_project(&temp);
         let build_dir = project.root.join("build");
 
-        let js = project.root.join("index.js");
-        assert!(is_relevant_path(&js, &project, &build_dir));
+        let spec = WatchAssetSpec::new(
+            vec![],
+            vec![(project.root.clone(), vec!["images/**".to_string()])],
+            vec![],
+        );
+
+        let matched = project.root.join("images").join("logo.png");
+        assert!(is_relevant_path(&matched, &project, &build_dir, &spec));
+
+        let unmatched = project.root.join("docs").join("notes.md");
+        assert!(!is_relevant_path(&unmatched, &project, &build_dir, &spec));
     }
 
     #[test]
-    fn test_css_under_build_dir_is_excluded() {
+    fn test_package_asset_path_is_relevant() {
+        let temp = TempDir::new().unwrap();
+        let project = dir_project(&temp);
+        let build_dir = project.root.join("build");
+
+        // Simulate a package source root outside the project tree.
+        let pkg_root = TempDir::new().unwrap();
+        let pkg_css = pkg_root.path().join("assets").join("pkg.css");
+        let spec = WatchAssetSpec::new(
+            vec![pkg_css.clone()],
+            vec![],
+            vec![pkg_root.path().to_path_buf()],
+        );
+
+        assert!(is_relevant_path(&pkg_css, &project, &build_dir, &spec));
+        assert_eq!(spec.package_roots().len(), 1);
+
+        // A file under the package root that is not a declared asset is ignored.
+        let stray = pkg_root.path().join("assets").join("readme.bin");
+        assert!(!is_relevant_path(&stray, &project, &build_dir, &spec));
+    }
+
+    #[test]
+    fn test_typ_file_still_relevant() {
+        let temp = TempDir::new().unwrap();
+        let project = dir_project(&temp);
+        let build_dir = project.root.join("build");
+
+        let typ = project.root.join("chapters").join("intro.typ");
+        assert!(is_relevant_path(&typ, &project, &build_dir, &empty_spec()));
+    }
+
+    #[test]
+    fn test_asset_under_build_dir_is_excluded() {
         let temp = TempDir::new().unwrap();
         let project = dir_project(&temp);
         let build_dir = project.root.join("build");
         fs::create_dir_all(&build_dir).unwrap();
 
-        // File must exist so canonicalize-based exclusion applies.
+        // A generated asset under the build dir must never re-trigger the watcher,
+        // even if it is a declared asset source.
         let generated = build_dir.join("style.css");
         fs::write(&generated, "body {}").unwrap();
+        let spec = WatchAssetSpec::new(vec![generated.clone()], vec![], vec![]);
 
-        assert!(!is_relevant_path(&generated, &project, &build_dir));
+        assert!(!is_relevant_path(&generated, &project, &build_dir, &spec));
     }
 
     #[test]
-    fn test_single_file_css_asset_is_relevant() {
+    fn test_single_file_target_and_asset_relevant_others_not() {
         let temp = TempDir::new().unwrap();
         let file = temp.path().join("document.typ");
         fs::write(&file, "#heading[Test]").unwrap();
@@ -295,6 +443,19 @@ mod tests {
         let build_dir = project.root.join("build");
 
         let css = project.root.join("custom.css");
-        assert!(is_relevant_path(&css, &project, &build_dir));
+        let spec = WatchAssetSpec::new(vec![css.clone()], vec![], vec![]);
+
+        // The target file and the declared asset are relevant.
+        assert!(is_relevant_path(
+            &project.typ_files[0],
+            &project,
+            &build_dir,
+            &spec
+        ));
+        assert!(is_relevant_path(&css, &project, &build_dir, &spec));
+
+        // Another .typ file in the same directory is NOT relevant in single-file mode.
+        let other = project.root.join("other.typ");
+        assert!(!is_relevant_path(&other, &project, &build_dir, &spec));
     }
 }

--- a/crates/core/src/watch.rs
+++ b/crates/core/src/watch.rs
@@ -190,6 +190,25 @@ where
         }
     }
 
+    // The loaded config file may live outside the primary watched tree — in an
+    // ancestor directory (single-file walk-up) or at a custom `--config` path.
+    // Watch its parent directory (non-recursive) when it is not already covered,
+    // so config edits are detected regardless of mode or filename.
+    let primary_watch_dir = match project.mode {
+        ProjectMode::SingleFile => project.typ_files[0].parent(),
+        ProjectMode::Directory => Some(project.root.as_path()),
+    };
+    if let Some(config_parent) = project.config_path.as_deref().and_then(|p| p.parent())
+        && primary_watch_dir.is_none_or(|primary| !config_parent.starts_with(primary))
+    {
+        match watcher.watch(config_parent, RecursiveMode::NonRecursive) {
+            Ok(()) => debug!(path = %config_parent.display(), "watching config directory"),
+            Err(e) => {
+                warn!(error = %e, path = %config_parent.display(), "failed to watch config directory")
+            }
+        }
+    }
+
     // Debounce logic: collect events for 1 second before triggering recompilation
     // This prevents excessive recompilation when editors save multiple files rapidly
     // or when a single edit triggers multiple filesystem events
@@ -228,12 +247,7 @@ where
 
                             // Distinguish config changes from regular file changes
                             // Config changes require reloading project configuration
-                            if paths.iter().any(|p| {
-                                p.file_name()
-                                    .and_then(|n| n.to_str())
-                                    .map(|n| n == "rheo.toml")
-                                    .unwrap_or(false)
-                            }) {
+                            if paths.iter().any(|p| is_config_path(p, project)) {
                                 config_changed = true;
                             } else {
                                 pending_changes = true;
@@ -299,6 +313,11 @@ fn is_relevant_path(
         return false;
     }
 
+    // The config file is relevant in both modes (see `is_config_path`).
+    if is_config_path(path, project) {
+        return true;
+    }
+
     // A declared/resolved asset (from any plugin or imported package) or a
     // copy-glob match is relevant regardless of extension or location. This
     // covers both project-local assets and package assets under a package root.
@@ -317,11 +336,6 @@ fn is_relevant_path(
                 return true;
             }
 
-            // Check if it's rheo.toml
-            if path.file_name().and_then(|n| n.to_str()) == Some("rheo.toml") {
-                return true;
-            }
-
             // Check if it's a font file
             let font_extensions = ["ttf", "otf", "woff", "woff2"];
             path.extension()
@@ -330,6 +344,30 @@ fn is_relevant_path(
                 .unwrap_or(false)
         }
     }
+}
+
+/// True if `path` is the project's configuration file.
+///
+/// Matches the actually-loaded `project.config_path` (so a custom-named or
+/// relocated `--config` file is detected), and also any file literally named
+/// `rheo.toml` so that creating a config where none existed still triggers a
+/// reload.
+fn is_config_path(path: &Path, project: &ProjectConfig) -> bool {
+    if let Some(cfg) = project.config_path.as_deref()
+        && same_file(path, cfg)
+    {
+        return true;
+    }
+    path.file_name().and_then(|n| n.to_str()) == Some("rheo.toml")
+}
+
+/// Compare two paths for identity, tolerating non-canonical forms (e.g. a
+/// relative `--config` argument vs. an absolute event path).
+fn same_file(a: &Path, b: &Path) -> bool {
+    if a == b {
+        return true;
+    }
+    matches!((a.canonicalize(), b.canonicalize()), (Ok(a), Ok(b)) if a == b)
 }
 
 #[cfg(test)]
@@ -432,6 +470,75 @@ mod tests {
         let spec = WatchAssetSpec::new(vec![generated.clone()], vec![], vec![]);
 
         assert!(!is_relevant_path(&generated, &project, &build_dir, &spec));
+    }
+
+    /// A single-file project whose loaded config lives at `config_path`.
+    fn single_file_project(root: &Path, config_path: PathBuf) -> ProjectConfig {
+        ProjectConfig {
+            name: "document".into(),
+            root: root.to_path_buf(),
+            config: crate::RheoConfig::default(),
+            typ_files: vec![root.join("document.typ")],
+            mode: ProjectMode::SingleFile,
+            config_path: Some(config_path),
+        }
+    }
+
+    #[test]
+    fn test_config_file_relevant_in_single_file_mode() {
+        let temp = TempDir::new().unwrap();
+        let config = temp.path().join("rheo.toml");
+        let project = single_file_project(temp.path(), config.clone());
+        let build_dir = temp.path().join("build");
+
+        assert!(is_relevant_path(
+            &config,
+            &project,
+            &build_dir,
+            &empty_spec()
+        ));
+        assert!(is_config_path(&config, &project));
+    }
+
+    #[test]
+    fn test_custom_named_config_is_relevant() {
+        let temp = TempDir::new().unwrap();
+        let config = temp.path().join("prod.toml");
+        let project = single_file_project(temp.path(), config.clone());
+        let build_dir = temp.path().join("build");
+
+        // The custom-named config is detected via project.config_path...
+        assert!(is_relevant_path(
+            &config,
+            &project,
+            &build_dir,
+            &empty_spec()
+        ));
+        assert!(is_config_path(&config, &project));
+        // ...while an unrelated .toml is not.
+        let other = temp.path().join("other.toml");
+        assert!(!is_relevant_path(
+            &other,
+            &project,
+            &build_dir,
+            &empty_spec()
+        ));
+    }
+
+    #[test]
+    fn test_sibling_rheo_toml_relevant_in_directory_mode() {
+        let temp = TempDir::new().unwrap();
+        let project = dir_project(&temp);
+        let build_dir = project.root.join("build");
+
+        // Directory mode with no loaded config still reacts to a rheo.toml by name.
+        let config = project.root.join("rheo.toml");
+        assert!(is_relevant_path(
+            &config,
+            &project,
+            &build_dir,
+            &empty_spec()
+        ));
     }
 
     #[test]

--- a/crates/html/src/server.rs
+++ b/crates/html/src/server.rs
@@ -348,8 +348,11 @@ fn directory_listing(html_dir: &Path, path: &str) -> Response {
         html.push_str("<li>No HTML files found</li>");
     } else {
         for file in html_files {
+            // Prefix the href with `./` so a colon in a nested vertebra's
+            // filename (e.g. `chapters:intro.html`) isn't parsed as a URL
+            // scheme by the browser, which would break the link.
             html.push_str(&format!(
-                r#"        <li><a href="{}">{}</a></li>
+                r#"        <li><a href="./{}">{}</a></li>
 "#,
                 file, file
             ));
@@ -413,5 +416,30 @@ mod tests {
 
         let result = bind_in_range(taken, taken).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_directory_listing_prefixes_href_for_colon_filenames() {
+        // Nested vertebrae land on disk as flat, colon-separated filenames
+        // (e.g. `chapters:intro.html`). The listing must not emit a bare
+        // `href="chapters:intro.html"` — the browser would read `chapters:`
+        // as a URL scheme and break the link. A `./` prefix fixes it.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("chapters:intro.html"), "<html></html>").unwrap();
+
+        let response = directory_listing(dir.path(), "");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(
+            html.contains(r#"href="./chapters:intro.html""#),
+            "expected a `./`-prefixed href, got: {html}"
+        );
+        assert!(
+            !html.contains(r#"href="chapters:intro.html""#),
+            "bare colon href would be parsed as a URL scheme: {html}"
+        );
     }
 }

--- a/crates/html/src/server.rs
+++ b/crates/html/src/server.rs
@@ -72,13 +72,11 @@ pub async fn start_server_with_virtual_fs(
         .fallback(get(static_handler))
         .with_state(state);
 
-    // Bind to address
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .map_err(|e| crate::RheoError::io(e, format!("binding to {}", addr)))?;
+    // Bind to an available port, advancing past ones already in use.
+    let listener = bind_available_port(port).await?;
+    let actual_port = listener.local_addr().map(|a| a.port()).unwrap_or(port);
 
-    let server_url = format!("http://localhost:{}", port);
+    let server_url = format!("http://localhost:{}", actual_port);
     info!(url = %server_url, "web server started");
 
     // Spawn server task
@@ -89,6 +87,42 @@ pub async fn start_server_with_virtual_fs(
     });
 
     Ok((server_handle, reload_tx, server_url, vfs_arc))
+}
+
+/// Highest port the dev server will try before giving up (inclusive).
+const MAX_PORT: u16 = 3050;
+
+/// Bind a `TcpListener` on `127.0.0.1`, starting at `start_port` and advancing
+/// to the next port when one is already in use, up to [`MAX_PORT`] inclusive.
+async fn bind_available_port(start_port: u16) -> Result<tokio::net::TcpListener> {
+    bind_in_range(start_port, MAX_PORT).await
+}
+
+/// Bind on `127.0.0.1`, trying `start_port..=max_port` in order.
+///
+/// Only `AddrInUse` advances to the next port; any other bind error surfaces
+/// immediately. If every port in the range is taken, returns an error naming it.
+async fn bind_in_range(start_port: u16, max_port: u16) -> Result<tokio::net::TcpListener> {
+    let mut last_in_use = None;
+    for port in start_port..=max_port {
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => return Ok(listener),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                warn!(port, "port already in use, trying next");
+                last_in_use = Some(e);
+            }
+            Err(e) => return Err(crate::RheoError::io(e, format!("binding to {}", addr))),
+        }
+    }
+
+    let err = last_in_use.unwrap_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::AddrInUse, "no ports available")
+    });
+    Err(crate::RheoError::io(
+        err,
+        format!("all ports {}-{} are in use", start_port, max_port),
+    ))
 }
 
 /// SSE handler for live reload events
@@ -340,4 +374,44 @@ pub fn open_browser(url: &str) -> Result<()> {
     info!(url = %url, "opening browser");
     webbrowser::open(url)
         .map_err(|e| crate::RheoError::project_config(format!("failed to open browser: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn test_bind_advances_past_occupied_port() {
+        // Hold an ephemeral port, then ask to start binding at it.
+        let occupied = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let taken = occupied.local_addr().unwrap().port();
+
+        let listener = bind_in_range(taken, taken.saturating_add(10))
+            .await
+            .unwrap();
+        let got = listener.local_addr().unwrap().port();
+        assert!(got > taken, "expected a port above {taken}, got {got}");
+    }
+
+    #[tokio::test]
+    async fn test_bind_uses_start_port_when_free() {
+        // Find a free port, release it, then confirm we bind exactly it.
+        let probe = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let free = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let listener = bind_in_range(free, free).await.unwrap();
+        assert_eq!(listener.local_addr().unwrap().port(), free);
+    }
+
+    #[tokio::test]
+    async fn test_bind_errors_when_range_exhausted() {
+        // The single port in range is occupied, so binding must fail.
+        let occupied = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let taken = occupied.local_addr().unwrap().port();
+
+        let result = bind_in_range(taken, taken).await;
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
Closes #81.

- Improves the handling of changes to assets in the dev server.
- Auto-increments the local port on which the dev server runs if 3000 is busy.