### PR TITLE
Incorporates target as part of `rheo-context`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ rheo injects a per-vertebra Typst variable `rheo-context` into every spine file,
 Fields (v1; the value is a dictionary and may gain fields later):
 - `handle` — this file's `:`-separated handle (its ID; the same handle used for the cross-file links above).
 - `spine` — a flat list of every vertebra in spine order, each an entry `(handle, path, title)`.
+- `target` — the rheo output-format name (`"epub"`/`"html"`/…). Present only for formats that set one; **absent for PDF**, where documents fall back to Typst's native `target()` == `"paged"`. Identical across vertebrae, so it also rides on the global `sys.inputs.rheo-context`.
 
 ```typst
 This is #rheo-context.handle of #rheo-context.spine.len() pages.
@@ -128,6 +129,8 @@ This is #rheo-context.handle of #rheo-context.spine.len() pages.
 ```
 
 A package needing only the shared spine can read `sys.inputs.rheo-context.spine` directly and never touch the per-file `#let`.
+
+**Output format.** The output format is read from `sys.inputs.rheo-context.target` (globally, same value for every vertebra). rheo injects a `target()` polyfill so Typst's own `target()` returns this value (`"epub"`/`"html"`, or native `"paged"` for PDF), and the injected template exposes `is-rheo-epub()`/`is-rheo-html()`/`is-rheo-pdf()` helpers that read it. Prefer `target()` (or those helpers) over reading the field directly. The older `sys.inputs.rheo-target` key has been **removed** — use `sys.inputs.rheo-context.target`.
 
 **Section-label namespacing is a package concern, not core.** rheo does not rewrite or prefix authored labels; label semantics stay exactly as Typst defines them (two vertebrae defining the same label collide as an ordinary Typst duplicate-label error). Packages such as `@rheo/zettelkasten` use `rheo-context` to *additively* synthesize globally-unique `<handle:label>` section anchors alongside the author's own labels.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ This is #rheo-context.handle of #rheo-context.spine.len() pages.
 
 A package needing only the shared spine can read `sys.inputs.rheo-context.spine` directly and never touch the per-file `#let`.
 
-**Output format.** The output format is read from `sys.inputs.rheo-context.target` (globally, same value for every vertebra). rheo injects a `target()` polyfill so Typst's own `target()` returns this value (`"epub"`/`"html"`, or native `"paged"` for PDF), and the injected template exposes `is-rheo-epub()`/`is-rheo-html()`/`is-rheo-pdf()` helpers that read it. Prefer `target()` (or those helpers) over reading the field directly. The older `sys.inputs.rheo-target` key has been **removed** — use `sys.inputs.rheo-context.target`.
+**Output format.** rheo injects a `target()` polyfill into every file so Typst's own `target()` returns the output format (`"epub"`/`"html"`, or native `"paged"` for PDF), reading it from `sys.inputs.rheo-context.target`. Authored files should detect the format with `target()` (e.g. `target() == "epub"`); it is the only per-file API. The underlying `sys.inputs.rheo-context.target` is the same value for every vertebra but is not in scope where the polyfill isn't (it is global, so reachable via `sys.inputs`). The older `sys.inputs.rheo-target` key has been **removed**.
 
 **Section-label namespacing is a package concern, not core.** rheo does not rewrite or prefix authored labels; label semantics stay exactly as Typst defines them (two vertebrae defining the same label collide as an ordinary Typst duplicate-label error). Packages such as `@rheo/zettelkasten` use `rheo-context` to *additively* synthesize globally-unique `<handle:label>` section anchors alongside the author's own labels.
 

--- a/crates/cli/src/migrate.rs
+++ b/crates/cli/src/migrate.rs
@@ -15,6 +15,15 @@
 //! indistinguishable without full project context. Projects that adopted the
 //! old `-` scheme during that pre-release window must update their links
 //! manually; `rheo migrate --dry-run` shows the new canonical handles.
+//!
+//! # Output format: `rheo-target` → `rheo-context.target`
+//!
+//! The `sys.inputs.rheo-target` key and the injected `rheo-target()` helper were
+//! removed; the output format now lives on `sys.inputs.rheo-context.target`
+//! and is surfaced through Typst's polyfilled `target()`. Projects upgrading from
+//! an older version have their direct references rewritten (`migrate_target_references`).
+//! Authors using the `is-rheo-epub()`/`is-rheo-html()`/`is-rheo-pdf()` helpers
+//! need no change — those already read the new location.
 
 use regex::{Captures, Regex};
 use rheo_core::build::resolve_effective_content_dir;
@@ -61,15 +70,30 @@ pub fn migrate_project(path: &Path, apply: bool) -> Result<()> {
     let link_threshold = ManifestVersion::parse(LINK_SYNTAX_VERSION).expect("valid semver");
     let needs_link_rewrite = from < link_threshold;
 
+    // `rheo-target` was removed as of the current release, so any project on an
+    // older version (i.e. every project reaching this point past the up-to-date
+    // check above) has its direct references rewritten.
+    let needs_target_rewrite = from < to;
+
     println!("\nMigrations:");
     if needs_link_rewrite {
         println!("  - rewrite #link(\"./file.typ\") syntax to #link(<handle>)");
+    }
+    if needs_target_rewrite {
+        println!(
+            "  - rewrite sys.inputs.rheo-target -> sys.inputs.rheo-context.target (and rheo-target() -> target())"
+        );
     }
     println!("  - bump rheo.toml version to {to}");
 
     if needs_link_rewrite {
         println!("\nLink rewrites:");
         migrate_link_syntax(&project, apply)?;
+    }
+
+    if needs_target_rewrite {
+        println!("\nTarget references:");
+        migrate_target_references(&project, apply)?;
     }
 
     if apply {
@@ -159,6 +183,88 @@ fn migrate_link_syntax(project: &ProjectConfig, apply: bool) -> Result<()> {
 
         if changed && apply {
             fs::write(file, rewritten.as_bytes())
+                .map_err(|e| RheoError::io(e, format!("failed to write {}", file.display())))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Rewrite direct author references to the removed `sys.inputs.rheo-target` key
+/// into the `sys.inputs.rheo-context.target` form, and calls to the removed
+/// `rheo-target()` helper into Typst's polyfilled `target()`.
+///
+/// Three textual forms are handled, in order (no rewrite's output contains
+/// another rule's match text, so the passes are independent):
+/// - `rheo-target()`               -> `target()`
+/// - `"rheo-target" in sys.inputs` -> `"rheo-context" in sys.inputs and "target" in sys.inputs.rheo-context`
+/// - `sys.inputs.rheo-target`      -> `sys.inputs.rheo-context.target`
+///
+/// Authors using the injected `is-rheo-epub()`/`is-rheo-html()`/`is-rheo-pdf()`
+/// helpers need no change — those already read the new location. Any file still
+/// containing the literal `rheo-target` afterwards (e.g. a
+/// `sys.inputs.at("rheo-target")` form this does not rewrite) is reported with a
+/// `warn!` for manual fixing.
+fn migrate_target_references(project: &ProjectConfig, apply: bool) -> Result<()> {
+    let content_dir = resolve_effective_content_dir(project);
+    let typ_files = collect_typ_files(&content_dir);
+    if typ_files.is_empty() {
+        return Ok(());
+    }
+
+    let rules: [(Regex, &str, &str); 3] = [
+        (
+            Regex::new(r"rheo-target\(\s*\)").expect("hardcoded regex must compile"),
+            "target()",
+            "rheo-target()  ->  target()",
+        ),
+        (
+            Regex::new(r#""rheo-target"\s+in\s+sys\.inputs"#).expect("hardcoded regex must compile"),
+            r#""rheo-context" in sys.inputs and "target" in sys.inputs.rheo-context"#,
+            "\"rheo-target\" in sys.inputs  ->  \"rheo-context\" in sys.inputs and \"target\" in sys.inputs.rheo-context",
+        ),
+        (
+            Regex::new(r"sys\.inputs\.rheo-target").expect("hardcoded regex must compile"),
+            "sys.inputs.rheo-context.target",
+            "sys.inputs.rheo-target  ->  sys.inputs.rheo-context.target",
+        ),
+    ];
+
+    for file in &typ_files {
+        let mut content = match fs::read_to_string(file) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(file = %file.display(), error = %e, "skipping unreadable file");
+                continue;
+            }
+        };
+        let mut changed = false;
+
+        for (re, replacement, label) in &rules {
+            let mut hit = false;
+            let out = re.replace_all(&content, |caps: &Captures| -> String {
+                let line = line_number(&content, caps.get(0).unwrap().start());
+                info!(file = %file.display(), line, rewrite = label, "rewrite target reference");
+                println!("{}:{}: {}", file.display(), line, label);
+                hit = true;
+                (*replacement).to_string()
+            });
+            if hit {
+                content = out.into_owned();
+                changed = true;
+            }
+        }
+
+        // Forms this migration does not auto-rewrite leave the literal behind.
+        if content.contains("rheo-target") {
+            warn!(
+                file = %file.display(),
+                "residual `rheo-target` reference remains after migration; hand-fix to `rheo-context.target`"
+            );
+        }
+
+        if changed && apply {
+            fs::write(file, content.as_bytes())
                 .map_err(|e| RheoError::io(e, format!("failed to write {}", file.display())))?;
         }
     }
@@ -302,6 +408,55 @@ mod tests {
         assert!(rewritten.contains("#link(<about>)[About]"));
         // External URL untouched.
         assert!(rewritten.contains("#link(\"https://example.com\")[ex]"));
+    }
+
+    #[test]
+    fn rewrite_replaces_target_references() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let content = root.join("content");
+        fs::create_dir_all(&content).unwrap();
+        fs::write(
+            content.join("page.typ"),
+            "#let fmt = rheo-target()\n\
+             #if \"rheo-target\" in sys.inputs { sys.inputs.rheo-target }\n\
+             = Unrelated Title\n",
+        )
+        .unwrap();
+
+        let project = ProjectConfig {
+            root: root.to_path_buf(),
+            name: "test".into(),
+            config: rheo_core::RheoConfig {
+                version: ManifestVersion::parse("0.4.0").unwrap(),
+                content_dir: Some("content".into()),
+                ..Default::default()
+            },
+            typ_files: vec![content.join("page.typ")],
+            mode: rheo_core::config::project::ProjectMode::Directory,
+            config_path: Some(root.join("rheo.toml")),
+        };
+        fs::write(
+            root.join("rheo.toml"),
+            "version = \"0.4.0\"\ncontent_dir = \"content\"\n",
+        )
+        .unwrap();
+
+        migrate_target_references(&project, true).unwrap();
+
+        let out = fs::read_to_string(content.join("page.typ")).unwrap();
+        // Helper call -> polyfilled target().
+        assert!(out.contains("#let fmt = target()"));
+        // Membership guard rewritten.
+        assert!(
+            out.contains("\"rheo-context\" in sys.inputs and \"target\" in sys.inputs.rheo-context")
+        );
+        // Value access rewritten.
+        assert!(out.contains("{ sys.inputs.rheo-context.target }"));
+        // No trace of the removed key/helper remains.
+        assert!(!out.contains("rheo-target"));
+        // Unrelated content untouched.
+        assert!(out.contains("= Unrelated Title"));
     }
 
     #[test]

--- a/crates/cli/src/migrate.rs
+++ b/crates/cli/src/migrate.rs
@@ -22,8 +22,8 @@
 //! removed; the output format now lives on `sys.inputs.rheo-context.target`
 //! and is surfaced through Typst's polyfilled `target()`. Projects upgrading from
 //! an older version have their direct references rewritten (`migrate_target_references`).
-//! Authors using the `is-rheo-epub()`/`is-rheo-html()`/`is-rheo-pdf()` helpers
-//! need no change — those already read the new location.
+//! Authors using the polyfilled `target()` need no change — it already reports
+//! the output format.
 
 use regex::{Captures, Regex};
 use rheo_core::build::resolve_effective_content_dir;
@@ -200,8 +200,8 @@ fn migrate_link_syntax(project: &ProjectConfig, apply: bool) -> Result<()> {
 /// - `"rheo-target" in sys.inputs` -> `"rheo-context" in sys.inputs and "target" in sys.inputs.rheo-context`
 /// - `sys.inputs.rheo-target`      -> `sys.inputs.rheo-context.target`
 ///
-/// Authors using the injected `is-rheo-epub()`/`is-rheo-html()`/`is-rheo-pdf()`
-/// helpers need no change — those already read the new location. Any file still
+/// Authors using the polyfilled `target()` need no change — it already reports
+/// the output format. Any file still
 /// containing the literal `rheo-target` afterwards (e.g. a
 /// `sys.inputs.at("rheo-target")` form this does not rewrite) is reported with a
 /// `warn!` for manual fixing.
@@ -219,7 +219,8 @@ fn migrate_target_references(project: &ProjectConfig, apply: bool) -> Result<()>
             "rheo-target()  ->  target()",
         ),
         (
-            Regex::new(r#""rheo-target"\s+in\s+sys\.inputs"#).expect("hardcoded regex must compile"),
+            Regex::new(r#""rheo-target"\s+in\s+sys\.inputs"#)
+                .expect("hardcoded regex must compile"),
             r#""rheo-context" in sys.inputs and "target" in sys.inputs.rheo-context"#,
             "\"rheo-target\" in sys.inputs  ->  \"rheo-context\" in sys.inputs and \"target\" in sys.inputs.rheo-context",
         ),
@@ -449,7 +450,9 @@ mod tests {
         assert!(out.contains("#let fmt = target()"));
         // Membership guard rewritten.
         assert!(
-            out.contains("\"rheo-context\" in sys.inputs and \"target\" in sys.inputs.rheo-context")
+            out.contains(
+                "\"rheo-context\" in sys.inputs and \"target\" in sys.inputs.rheo-context"
+            )
         );
         // Value access rewritten.
         assert!(out.contains("{ sys.inputs.rheo-context.target }"));

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -207,7 +207,7 @@ impl Build {
         virtual_spine.check_output_collisions()?;
 
         let moulded = virtual_spine.mould();
-        let rheo_context = virtual_spine.rheo_context_preludes();
+        let rheo_context = virtual_spine.rheo_context_preludes(plugin.rheo_target());
 
         // Single Typst bundle compile for this plugin.
         let world = RheoWorld::new_for_bundle(
@@ -215,7 +215,7 @@ impl Build {
             moulded.main,
             moulded.sources,
             rheo_context,
-            Some(virtual_spine.global_context()),
+            Some(virtual_spine.global_context(plugin.rheo_target())),
             plugin.rheo_target(),
             self.font_dirs.clone(),
         )?;

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -249,7 +249,7 @@ pub trait FormatPlugin: Send + Sync {
     ///
     /// 1. **CLI flag**: `--<name>` enables this format (e.g., `--html`)
     /// 2. **Output subdirectory**: files are written to `build/<name>/` (e.g., `build/html/`)
-    /// 3. **Format name**: passed to sys.inputs for `rheo-target()` polyfill injection
+    /// 3. **Format name**: threaded into `rheo-context.target` for the `target()` polyfill
     ///
     /// **Requirements:**
     /// - Must be stable (do not change between versions)
@@ -282,8 +282,8 @@ pub trait FormatPlugin: Send + Sync {
         TypstFormat::Html
     }
 
-    /// The value injected as `sys.inputs.rheo-target`, surfaced to documents via
-    /// the `target()` polyfill.
+    /// The output-format name written into `sys.inputs.rheo-context.target`,
+    /// surfaced to documents via the `target()` polyfill.
     ///
     /// This keeps formats that share a Typst export target distinguishable: EPUB
     /// and HTML both compile via the `html` target, but report `"epub"` and

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -278,15 +278,23 @@ impl VirtualSpine {
     /// `spine` literal is identical across files. The shape is a dictionary so
     /// attributes can be added later (e.g. by format plugins) without breaking
     /// consumers.
-    pub fn rheo_context_preludes(&self) -> HashMap<String, String> {
+    ///
+    /// `target` is the output-format name (e.g. `"html"`/`"epub"`); when
+    /// `Some`, a `target` field is added to the dict, and when `None` (PDF) it
+    /// is omitted so consumers fall back to Typst's native `target()`.
+    pub fn rheo_context_preludes(&self, target: Option<&str>) -> HashMap<String, String> {
         let spine = self.spine_data();
         self.vertebrae
             .iter()
             .map(|v| {
-                let context = TypstLiteral::Dict(vec![
+                let mut fields = vec![
                     ("handle".to_string(), TypstLiteral::str(v.handle.as_str())),
                     ("spine".to_string(), spine.clone()),
-                ]);
+                ];
+                if let Some(t) = target {
+                    fields.push(("target".to_string(), TypstLiteral::str(t)));
+                }
+                let context = TypstLiteral::Dict(fields);
                 let prelude = format!("#let rheo-context = {}\n\n", context.serialize());
                 (v.rel_path.clone(), prelude)
             })
@@ -300,8 +308,15 @@ impl VirtualSpine {
     /// read `sys.inputs.rheo-context` to detect a rheo build (and reach the shared
     /// spine) without referencing the per-file `#let rheo-context`, which
     /// additionally carries this file's `handle`.
-    pub fn global_context(&self) -> TypstLiteral {
-        TypstLiteral::Dict(vec![("spine".to_string(), self.spine_data())])
+    ///
+    /// `target` follows the same rule as [`Self::rheo_context_preludes`]: a
+    /// `target` field is added when `Some`, omitted for PDF (`None`).
+    pub fn global_context(&self, target: Option<&str>) -> TypstLiteral {
+        let mut fields = vec![("spine".to_string(), self.spine_data())];
+        if let Some(t) = target {
+            fields.push(("target".to_string(), TypstLiteral::str(t)));
+        }
+        TypstLiteral::Dict(fields)
     }
 
     /// The flat spine as a [`TypstLiteral`] array-of-dictionaries: one entry per
@@ -586,7 +601,7 @@ mod tests {
         };
         let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
 
-        let preludes = spine.rheo_context_preludes();
+        let preludes = spine.rheo_context_preludes(Some("html"));
         // One prelude per vertebra, keyed by include path.
         assert_eq!(preludes.len(), 2);
         let root_prelude = &preludes["content/intro.typ"];
@@ -601,6 +616,37 @@ mod tests {
             assert!(p.contains("path: \"content/intro.typ\""));
             assert!(p.contains("path: \"content/chapters/intro.typ\""));
         }
+    }
+
+    #[test]
+    fn rheo_context_target_present_when_some_absent_when_none() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let content = root.join("content");
+        fs::create_dir_all(&content).unwrap();
+        fs::write(content.join("intro.typ"), "= Intro\n").unwrap();
+
+        let files = vec![content.join("intro.typ")];
+        let layout = SpineLayout::OnePerVertebra {
+            ext: "html".into(),
+            format: "html".into(),
+        };
+        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+
+        // Some(target) -> `target` field in both prelude and global context.
+        let with = spine.rheo_context_preludes(Some("html"));
+        assert!(with["content/intro.typ"].contains("target: \"html\""));
+        assert!(
+            spine
+                .global_context(Some("html"))
+                .serialize()
+                .contains("target: \"html\"")
+        );
+
+        // None (PDF) -> no `target` field anywhere.
+        let without = spine.rheo_context_preludes(None);
+        assert!(!without["content/intro.typ"].contains("target:"));
+        assert!(!spine.global_context(None).serialize().contains("target:"));
     }
 
     #[test]

--- a/crates/core/src/typ/rheo.typ
+++ b/crates/core/src/typ/rheo.typ
@@ -1,19 +1,13 @@
-// Get the rheo output format, with fallback to Typst's target()
-// Returns: "epub", "html", "pdf" when compiled with rheo
-//          "html" or "paged" when compiled with vanilla Typst
-#let rheo-target() = {
-  if "rheo-target" in sys.inputs {
-    sys.inputs.rheo-target
-  } else {
-    target()
-  }
-}
+// The rheo output format is surfaced through Typst's own `target()`: rheo
+// injects a `target()` polyfill that returns "epub"/"html"/"paged" from
+// `sys.inputs.rheo-context.target`, falling back to `std.target()` under vanilla
+// Typst. There is no separate `rheo-target()` — use `target()` directly.
 
-// Check if we're compiling for a specific rheo format
-// Works in vanilla Typst (returns false when rheo-target not set)
-#let is-rheo-epub() = "rheo-target" in sys.inputs and sys.inputs.rheo-target == "epub"
-#let is-rheo-html() = "rheo-target" in sys.inputs and sys.inputs.rheo-target == "html"
-#let is-rheo-pdf() = "rheo-target" in sys.inputs and sys.inputs.rheo-target == "pdf"
+// Check if we're compiling for a specific rheo format.
+// Works in vanilla Typst (returns false when there is no rheo-context).
+#let is-rheo-epub() = "rheo-context" in sys.inputs and sys.inputs.rheo-context.at("target", default: none) == "epub"
+#let is-rheo-html() = "rheo-context" in sys.inputs and sys.inputs.rheo-context.at("target", default: none) == "html"
+#let is-rheo-pdf() = "rheo-context" in sys.inputs and sys.inputs.rheo-context.at("target", default: none) == "pdf"
 
 #let rheo_template(doc) = context {
   doc
@@ -45,7 +39,7 @@
     if matches.len() > 0 {
       let elem = matches.first()
       if elem.func() == figure and elem.kind == "rheo-handle" {
-        let fmt = rheo-target()
+        let fmt = target()
         let ext = if fmt == "epub" { ".xhtml" } else if fmt == "html" { ".html" } else { none }
         if ext != none {
           let handle = repr(it.dest).slice(1, -1)

--- a/crates/core/src/typ/rheo.typ
+++ b/crates/core/src/typ/rheo.typ
@@ -1,13 +1,8 @@
 // The rheo output format is surfaced through Typst's own `target()`: rheo
-// injects a `target()` polyfill that returns "epub"/"html"/"paged" from
-// `sys.inputs.rheo-context.target`, falling back to `std.target()` under vanilla
-// Typst. There is no separate `rheo-target()` — use `target()` directly.
-
-// Check if we're compiling for a specific rheo format.
-// Works in vanilla Typst (returns false when there is no rheo-context).
-#let is-rheo-epub() = "rheo-context" in sys.inputs and sys.inputs.rheo-context.at("target", default: none) == "epub"
-#let is-rheo-html() = "rheo-context" in sys.inputs and sys.inputs.rheo-context.at("target", default: none) == "html"
-#let is-rheo-pdf() = "rheo-context" in sys.inputs and sys.inputs.rheo-context.at("target", default: none) == "pdf"
+// injects a `target()` polyfill (into every file) that returns
+// "epub"/"html"/"paged" from `sys.inputs.rheo-context.target`, falling back to
+// `std.target()` under vanilla Typst. Detect the format with `target() == "epub"`
+// etc. There is no `rheo-target()` helper — use `target()` directly.
 
 #let rheo_template(doc) = context {
   doc

--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -10,7 +10,7 @@ use codespan_reporting::files::{Error as CodespanError, Files};
 use parking_lot::Mutex;
 use tracing::warn;
 use typst::diag::{FileError, FileResult};
-use typst::foundations::{Bytes, Datetime, Dict, IntoValue};
+use typst::foundations::{Bytes, Datetime, Dict};
 use typst::syntax::{FileId, Lines, RootedPath, Source, VirtualPath, VirtualRoot};
 use typst::text::{Font, FontBook};
 use typst::utils::LazyHash;
@@ -22,11 +22,12 @@ use typst_library::Feature;
 use typst_library::foundations::Duration;
 
 /// Build sys.inputs Dict for Typst compilation.
-fn build_inputs(format_name: Option<&str>, rheo_context: Option<&TypstLiteral>) -> Dict {
+///
+/// The output format is surfaced only via `rheo-context.target` (read by the
+/// injected `target()` polyfill and the `rheo.typ` helpers); there is no
+/// separate `rheo-target` key.
+fn build_inputs(rheo_context: Option<&TypstLiteral>) -> Dict {
     let mut dict = Dict::new();
-    if let Some(name) = format_name {
-        dict.insert("rheo-target".into(), name.into_value());
-    }
     if let Some(ctx) = rheo_context {
         dict.insert("rheo-context".into(), ctx.to_value());
     }
@@ -88,7 +89,7 @@ impl RheoWorld {
 
         let library = Library::builder()
             .with_features([Feature::Html, Feature::Bundle].into_iter().collect())
-            .with_inputs(build_inputs(format_name, None))
+            .with_inputs(build_inputs(None))
             .build();
 
         let (font_store, package_storage, rheo_packages) = Self::init_resources(&font_dirs);
@@ -138,7 +139,7 @@ impl RheoWorld {
 
         let library = Library::builder()
             .with_features([Feature::Html, Feature::Bundle].into_iter().collect())
-            .with_inputs(build_inputs(format_name, global_context.as_ref()))
+            .with_inputs(build_inputs(global_context.as_ref()))
             .build();
 
         let (font_store, package_storage, rheo_packages) = Self::init_resources(&font_dirs);
@@ -382,7 +383,7 @@ impl World for RheoWorld {
         // Inject target() polyfill for all plugin formats.
         let target_polyfill = if self.format_name.is_some() {
             "// Polyfill target() to return rheo's output format from sys.inputs\n\
-             #let target() = if \"rheo-target\" in sys.inputs { sys.inputs.rheo-target } else { std.target() }\n\n"
+             #let target() = if \"rheo-context\" in sys.inputs and \"target\" in sys.inputs.rheo-context { sys.inputs.rheo-context.target } else { std.target() }\n\n"
         } else {
             ""
         };
@@ -584,13 +585,17 @@ mod tests {
     }
 
     #[test]
-    fn build_inputs_includes_rheo_context() {
-        let ctx = TypstLiteral::Dict(vec![("spine".to_string(), TypstLiteral::Array(vec![]))]);
-        let dict = build_inputs(Some("html"), Some(&ctx));
+    fn build_inputs_includes_rheo_context_and_no_rheo_target() {
+        let ctx = TypstLiteral::Dict(vec![
+            ("spine".to_string(), TypstLiteral::Array(vec![])),
+            ("target".to_string(), TypstLiteral::str("html")),
+        ]);
+        let dict = build_inputs(Some(&ctx));
         assert!(dict.contains("rheo-context"));
-        assert!(dict.contains("rheo-target"));
+        // The deprecated top-level key is gone; format lives in rheo-context.target.
+        assert!(!dict.contains("rheo-target"));
 
-        let empty = build_inputs(None, None);
+        let empty = build_inputs(None);
         assert!(!empty.contains("rheo-context"));
         assert!(!empty.contains("rheo-target"));
     }


### PR DESCRIPTION
Moves the output format off the standalone `sys.inputs.rheo-target` key onto a `target` field of `rheo-context`, so the build context lives in one place. Follows #149.

- Adds an optional `target` to `rheo-context` — on both the per-vertebra `#let` prelude and the global `sys.inputs.rheo-context` (`rheo_context_preludes`/`global_context`, `crates/core/src/reticulate/spine.rs`). Set for HTML/EPUB; absent for PDF, so `target()` keeps its native `"paged"`.
- The `target()` polyfill and `build_inputs` now read `sys.inputs.rheo-context.target`; the `sys.inputs.rheo-target` key is dropped (`crates/core/src/world.rs`).
- Removes the `rheo-target()` helper — with the polyfill it was just `target()`. Authored files use `target()` directly.
- Removes the `is-rheo-epub/html/pdf()` helpers from `rheo.typ`. They were unreachable: `rheo.typ` is injected only into the synthetic main, and authored vertebrae are `#include`d and never see it. Format detection is `target()` (e.g. `target() == "epub"`).

# Migration

`rheo migrate` rewrites direct references in `.typ` sources for any project older than the current release:

- `rheo-target()` → `target()`
- `"rheo-target" in sys.inputs` → `"rheo-context" in sys.inputs and "target" in sys.inputs.rheo-context`
- `sys.inputs.rheo-target` → `sys.inputs.rheo-context.target`

Dry run reports each rewrite with `file:line`; `--apply` writes them and warns on any residual `rheo-target` literal it doesn't cover.

Docs updated (CLAUDE.md `rheo-context` section, `FormatPlugin` rustdoc). The `0.5.0` version bump lands separately.
