### PR TITLE
Restructures spine configuration for finer-grained control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,15 @@ dest           = "subdir"  # optional; output subdirectory for this block's file
 css_stylesheet = "two.css"
 js_scripts     = "two.js"
 
+[spine]
+exclude = ["drafts/**"]  # optional; glob patterns (relative to content_dir) omitted from every format's scan
+
+[[spine.section]]
+name = "chapters"        # optional; virtual-directory regrouping without moving files on disk
+include = ["ch-*.typ"]
+
 [pdf.spine]
-title = "My Book"
-vertebrae = ["cover.typ", "chapters/**/*.typ"]
+title = "My Book"        # per-format override; only the fields set here replace the global [spine]'s
 
 [epub]
 identifier = "urn:uuid:..."  # optional, auto-generated
@@ -74,7 +80,6 @@ date = 2025-01-15T00:00:00Z
 
 [epub.spine]
 title = "My Book"
-vertebrae = ["cover.typ", "chapters/**/*.typ"]
 ```
 
 Precedence: CLI flags > rheo.toml > built-in defaults. Without rheo.toml, title and spine are inferred from filename/directory.
@@ -137,7 +142,15 @@ A package needing only the shared spine can read `sys.inputs.rheo-context.spine`
 
 ## Spine configuration
 
-**Spine vertebrae:** The `vertebrae` array in `[pdf.spine]` or `[epub.spine]` specifies which source files to include and in what order. Glob patterns are supported (e.g., `chapters/**/*.typ`).
+**Directory-scan default:** with no `[spine]`/`[<format>.spine]` at all, the spine is every `.typ` file under `content_dir`, recursively, ordered alphabetically per directory level. A directory whose landing file is `index.typ` or `<dirname>.typ` gets that directory's own handle (e.g. `chapters/chapters.typ` → `<chapters>`, not `<chapters:chapters>`); a directory with no landing file becomes a non-clickable group node with a prettified title (`01-intro/` → "Intro").
+
+**`[spine] exclude`:** glob patterns (relative to `content_dir`) for files/folders to omit from the scan.
+
+**`[[spine.section]]`:** groups matched files under a virtual directory without moving them on disk (e.g. `include = ["ch-*.typ"]` under `name = "chapters"` gives those files handles like `<chapters:ch-1>`). Nests via `[[spine.section.section]]`.
+
+**Precedence — field-by-field, not whole-table:** a per-format `[<format>.spine]` table can set `title`/`exclude`/`section` independently; any field it leaves unset falls back to the matching field on the global `[spine]` table (not the whole table at once). For example, `[pdf.spine] title = "My Book"` with no `exclude` of its own still inherits the global `[spine] exclude` — it does *not* silently drop it just because `[pdf.spine]` exists.
+
+The retired `vertebrae` glob-list key (pre-0.5.0) is no longer read; `rheo migrate` converts an old inclusion-filter `vertebrae` list into an equivalent `exclude`.
 
 PDF combines its spine into a single document by default; HTML and EPUB always produce per-page outputs. A `merge` key left in an old `rheo.toml` is silently ignored.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,13 +104,14 @@ rheo assigns each vertebra a canonical label derived from its path relative to t
 
 rheo injects a per-vertebra Typst variable `rheo-context` into every spine file, exposing rheo's view of the project to authored Typst and to packages. It is a plain top-level `#let` binding prepended to each file's source — an ordinary dictionary, **not** a Typst `context` value. Each vertebra gets its own values because rheo injects a distinct literal per file, not through Typst's context mechanism. Reading it therefore does **not** require the `#context` keyword:
 
-Fields (v1; the value is a dictionary and may gain fields later):
+Fields (the value is a dictionary and may gain fields later):
 - `handle` — this file's `:`-separated handle (its ID; the same handle used for the cross-file links above).
-- `spine` — a flat list of every vertebra in spine order, each an entry `(handle, path, title)`.
+- `spine` — the structured spine **tree**, mirroring directory/section nesting. Each node is a dict `(title, handle, path, children)`: a leaf (a vertebra) carries its own `handle`/`path`/`title`; a group node (a directory or `[[spine.section]]` with no landing file) carries `handle: none`, `path: none`, and its own group title, nesting its children.
+- `spine-flat` — the flat pre-order list of every *clickable* vertebra (groups excluded), each an entry `(handle, path, title)` — the same shape the old flat `spine` used to be.
 - `target` — the rheo output-format name (`"epub"`/`"html"`/…). Present only for formats that set one; **absent for PDF**, where documents fall back to Typst's native `target()` == `"paged"`. Identical across vertebrae, so it also rides on the global `sys.inputs.rheo-context`.
 
 ```typst
-This is #rheo-context.handle of #rheo-context.spine.len() pages.
+This is #rheo-context.handle of #rheo-context.spine-flat.len() pages.
 ```
 
 **Passing it to packages:** a package template can't read the file's local `rheo-context` implicitly — Typst functions capture their definition scope, not the call site — so hand it in explicitly:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ A package needing only the shared spine can read `sys.inputs.rheo-context.spine`
 
 **Output format.** rheo injects a `target()` polyfill into every file so Typst's own `target()` returns the output format (`"epub"`/`"html"`, or native `"paged"` for PDF), reading it from `sys.inputs.rheo-context.target`. Authored files should detect the format with `target()` (e.g. `target() == "epub"`); it is the only per-file API. The underlying `sys.inputs.rheo-context.target` is the same value for every vertebra but is not in scope where the polyfill isn't (it is global, so reachable via `sys.inputs`). The older `sys.inputs.rheo-target` key has been **removed**.
 
-**Section-label namespacing is a package concern, not core.** rheo does not rewrite or prefix authored labels; label semantics stay exactly as Typst defines them (two vertebrae defining the same label collide as an ordinary Typst duplicate-label error). Packages such as `@rheo/zettelkasten` use `rheo-context` to *additively* synthesize globally-unique `<handle:label>` section anchors alongside the author's own labels.
+**Section-label namespacing is a package concern, not core.** rheo does not rewrite or prefix authored labels; label semantics stay exactly as Typst defines them (two vertebrae defining the same label collide as an ordinary Typst duplicate-label error). Packages such as `@rheo/notebox` use `rheo-context` to *additively* synthesize globally-unique `<handle:label>` section anchors alongside the author's own labels.
 
 ## Spine configuration
 

--- a/crates/cli/src/migrate.rs
+++ b/crates/cli/src/migrate.rs
@@ -29,7 +29,7 @@ use regex::{Captures, Regex};
 use rheo_core::build::resolve_effective_content_dir;
 use rheo_core::config::manifest_version::ManifestVersion;
 use rheo_core::config::project::ProjectConfig;
-use rheo_core::reticulate::{SpineLayout, VirtualSpine};
+use rheo_core::reticulate::{SpineLayout, SpineScan, VirtualSpine};
 use rheo_core::util::path::canonicalize_path;
 use rheo_core::{Result, RheoError};
 use std::collections::HashMap;
@@ -124,7 +124,7 @@ fn migrate_link_syntax(project: &ProjectConfig, apply: bool) -> Result<()> {
         ext: "html".into(),
         format: "html".into(),
     };
-    let spine = VirtualSpine::build(&typ_files, &content_dir, &project.root, layout)?;
+    let spine = VirtualSpine::build(SpineScan::flat(&typ_files, &content_dir), &project.root, layout)?;
 
     // Canonical absolute source path -> label to emit.
     // The primary handle is always unique: bare (`intro`) for root-level files,

--- a/crates/cli/src/migrate.rs
+++ b/crates/cli/src/migrate.rs
@@ -30,9 +30,9 @@ use rheo_core::build::resolve_effective_content_dir;
 use rheo_core::config::manifest_version::ManifestVersion;
 use rheo_core::config::project::ProjectConfig;
 use rheo_core::reticulate::{SpineLayout, SpineScan, VirtualSpine};
-use rheo_core::util::path::canonicalize_path;
-use rheo_core::{Result, RheoError};
-use std::collections::HashMap;
+use rheo_core::util::path::{canonicalize_path, to_forward_slash};
+use rheo_core::{Result, RheoError, Spine};
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::{info, warn};
@@ -75,6 +75,10 @@ pub fn migrate_project(path: &Path, apply: bool) -> Result<()> {
     // check above) has its direct references rewritten.
     let needs_target_rewrite = from < to;
 
+    // `vertebrae` was retired by the structured-spine directory-scan default,
+    // in the same release as the rheo-target removal above — same threshold.
+    let needs_vertebrae_migration = from < to;
+
     println!("\nMigrations:");
     if needs_link_rewrite {
         println!("  - rewrite #link(\"./file.typ\") syntax to #link(<handle>)");
@@ -83,6 +87,9 @@ pub fn migrate_project(path: &Path, apply: bool) -> Result<()> {
         println!(
             "  - rewrite sys.inputs.rheo-target -> sys.inputs.rheo-context.target (and rheo-target() -> target())"
         );
+    }
+    if needs_vertebrae_migration {
+        println!("  - convert retired [spine] vertebrae glob lists to [spine] exclude");
     }
     println!("  - bump rheo.toml version to {to}");
 
@@ -94,6 +101,11 @@ pub fn migrate_project(path: &Path, apply: bool) -> Result<()> {
     if needs_target_rewrite {
         println!("\nTarget references:");
         migrate_target_references(&project, apply)?;
+    }
+
+    if needs_vertebrae_migration {
+        println!("\nSpine config:");
+        migrate_vertebrae_to_exclude(&project, config_path, apply)?;
     }
 
     if apply {
@@ -272,6 +284,179 @@ fn migrate_target_references(project: &ProjectConfig, apply: bool) -> Result<()>
             fs::write(file, content.as_bytes())
                 .map_err(|e| RheoError::io(e, format!("failed to write {}", file.display())))?;
         }
+    }
+
+    Ok(())
+}
+
+/// One `[spine]`/`[<plugin>.spine]` table that still sets the retired
+/// `vertebrae` glob list.
+struct VertebraeSite {
+    /// `None` for the global `[spine]` table, `Some(plugin name)` for a
+    /// per-format `[<plugin>.spine]` table.
+    plugin: Option<String>,
+    patterns: Vec<String>,
+}
+
+impl VertebraeSite {
+    fn label(&self) -> String {
+        match &self.plugin {
+            Some(name) => format!("{name}.spine"),
+            None => "spine".to_string(),
+        }
+    }
+}
+
+/// Read `spine.extra`'s `vertebrae` key (captured there since the typed field
+/// was removed — see rheo-cyy) as a list of glob-pattern strings.
+fn vertebrae_patterns(spine: &Spine) -> Option<Vec<String>> {
+    let patterns = spine.extra.get("vertebrae")?.as_array()?;
+    Some(
+        patterns
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+    )
+}
+
+/// Expand `vertebrae` glob patterns into the `.typ` files they matched, the
+/// same way the retired `SpineOptions::generate` used to (glob each pattern
+/// against `content_dir`, keep only `.typ` files). Paths are canonicalized so
+/// they compare equal to the directory-scan set regardless of path spelling.
+fn expand_vertebrae_patterns(patterns: &[String], content_dir: &Path) -> HashSet<PathBuf> {
+    let mut matched = HashSet::new();
+    for pattern in patterns {
+        let glob_pattern = content_dir.join(pattern).display().to_string();
+        let Ok(paths) = glob::glob(&glob_pattern) else {
+            continue;
+        };
+        for path in paths.filter_map(|p| p.ok()) {
+            if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("typ") {
+                matched.insert(canonicalize_path(&path).unwrap_or(path));
+            }
+        }
+    }
+    matched
+}
+
+/// Convert a retired `vertebrae` inclusion-filter glob list into an equivalent
+/// `[spine] exclude`, so a helper-only `.typ` file the old list deliberately
+/// never named doesn't silently start being published as a spine page under
+/// the directory-scan-by-default model (see rheo-9vl.1). When `vertebrae`
+/// matched every `.typ` file anyway (e.g. an empty list, or a catch-all glob),
+/// no exclude is needed — the key is simply dropped.
+fn migrate_vertebrae_to_exclude(
+    project: &ProjectConfig,
+    config_path: &Path,
+    apply: bool,
+) -> Result<()> {
+    let mut sites = Vec::new();
+    if let Some(spine) = &project.config.spine
+        && let Some(patterns) = vertebrae_patterns(spine)
+    {
+        sites.push(VertebraeSite {
+            plugin: None,
+            patterns,
+        });
+    }
+    for (name, section) in &project.config.plugin_sections {
+        if let Some(spine) = &section.spine
+            && let Some(patterns) = vertebrae_patterns(spine)
+        {
+            sites.push(VertebraeSite {
+                plugin: Some(name.clone()),
+                patterns,
+            });
+        }
+    }
+    if sites.is_empty() {
+        return Ok(());
+    }
+    // Sort for deterministic output across runs (HashMap iteration order varies).
+    sites.sort_by_key(|a| a.label());
+
+    let content_dir = resolve_effective_content_dir(project);
+    // Full directory-scan file set the new zero-config model would include.
+    // No `.typ` files under content_dir means nothing to reconcile.
+    let Ok(scan) = SpineScan::run(&content_dir, &[]) else {
+        return Ok(());
+    };
+    let scanned: HashSet<PathBuf> = scan
+        .files
+        .into_iter()
+        .map(|f| canonicalize_path(&f).unwrap_or(f))
+        .collect();
+
+    let text = fs::read_to_string(config_path)
+        .map_err(|e| RheoError::io(e, format!("failed to read {}", config_path.display())))?;
+    let mut doc: toml_edit::DocumentMut = text.parse().map_err(|e| {
+        RheoError::project_config(format!("failed to parse {}: {}", config_path.display(), e))
+    })?;
+
+    for site in &sites {
+        // An empty pattern list means "auto-discover everything" under the old
+        // semantics too — already equivalent to the new default, no diff.
+        let newly_included: Vec<String> = if site.patterns.is_empty() {
+            Vec::new()
+        } else {
+            let matched = expand_vertebrae_patterns(&site.patterns, &content_dir);
+            let mut rel: Vec<String> = scanned
+                .iter()
+                .filter(|f| !matched.contains(*f))
+                .map(|f| to_forward_slash(f.strip_prefix(&content_dir).unwrap_or(f)))
+                .collect();
+            rel.sort();
+            rel
+        };
+
+        if newly_included.is_empty() {
+            println!(
+                "  - [{}]: vertebrae matched the full scan; removing (no exclude needed)",
+                site.label()
+            );
+        } else {
+            println!(
+                "  - [{}]: vertebrae -> exclude = {:?}",
+                site.label(),
+                newly_included
+            );
+        }
+
+        if apply {
+            let item = match &site.plugin {
+                Some(name) => &mut doc[name.as_str()]["spine"],
+                None => &mut doc["spine"],
+            };
+            if let Some(table) = item.as_table_like_mut() {
+                table.remove("vertebrae");
+                if !newly_included.is_empty() {
+                    match table.get_mut("exclude").and_then(|i| i.as_array_mut()) {
+                        Some(arr) => {
+                            for f in &newly_included {
+                                if !arr.iter().any(|v| v.as_str() == Some(f.as_str())) {
+                                    arr.push(f.as_str());
+                                }
+                            }
+                        }
+                        None => {
+                            let mut arr = toml_edit::Array::new();
+                            for f in &newly_included {
+                                arr.push(f.as_str());
+                            }
+                            table.insert(
+                                "exclude",
+                                toml_edit::Item::Value(toml_edit::Value::Array(arr)),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if apply {
+        fs::write(config_path, doc.to_string())
+            .map_err(|e| RheoError::io(e, format!("failed to write {}", config_path.display())))?;
     }
 
     Ok(())
@@ -464,6 +649,123 @@ mod tests {
         assert!(!out.contains("rheo-target"));
         // Unrelated content untouched.
         assert!(out.contains("= Unrelated Title"));
+    }
+
+    #[test]
+    fn vertebrae_migration_excludes_files_the_old_list_never_named() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let content = root.join("content");
+        fs::create_dir_all(content.join("lib")).unwrap();
+        fs::write(content.join("main.typ"), "= Main\n").unwrap();
+        fs::write(content.join("lib").join("helper.typ"), "#let x = 1\n").unwrap();
+
+        let mut extra = toml::Table::new();
+        extra.insert(
+            "vertebrae".to_string(),
+            toml::Value::Array(vec![toml::Value::String("main.typ".to_string())]),
+        );
+        let spine = Spine {
+            title: Some("Book".to_string()),
+            extra,
+            ..Default::default()
+        };
+        let mut plugin_sections = HashMap::new();
+        plugin_sections.insert(
+            "epub".to_string(),
+            rheo_core::PluginSection {
+                spine: Some(spine),
+                ..Default::default()
+            },
+        );
+
+        let project = ProjectConfig {
+            root: root.to_path_buf(),
+            name: "test".into(),
+            config: rheo_core::RheoConfig {
+                version: ManifestVersion::parse("0.3.0").unwrap(),
+                content_dir: Some("content".into()),
+                plugin_sections,
+                ..Default::default()
+            },
+            typ_files: vec![
+                content.join("main.typ"),
+                content.join("lib").join("helper.typ"),
+            ],
+            mode: rheo_core::config::project::ProjectMode::Directory,
+            config_path: Some(root.join("rheo.toml")),
+        };
+        let toml_path = root.join("rheo.toml");
+        fs::write(
+            &toml_path,
+            "version = \"0.3.0\"\ncontent_dir = \"content\"\n\n[epub.spine]\ntitle = \"Book\"\nvertebrae = [\"main.typ\"]\n",
+        )
+        .unwrap();
+
+        // Dry run: no write.
+        migrate_vertebrae_to_exclude(&project, &toml_path, false).unwrap();
+        let unchanged = fs::read_to_string(&toml_path).unwrap();
+        assert!(unchanged.contains("vertebrae"));
+
+        migrate_vertebrae_to_exclude(&project, &toml_path, true).unwrap();
+        let updated = fs::read_to_string(&toml_path).unwrap();
+        assert!(!updated.contains("vertebrae"), "{updated}");
+        assert!(updated.contains("exclude"), "{updated}");
+        assert!(updated.contains("lib/helper.typ"), "{updated}");
+        // Unrelated keys preserved.
+        assert!(updated.contains("title = \"Book\""), "{updated}");
+    }
+
+    #[test]
+    fn vertebrae_migration_drops_key_with_no_exclude_when_nothing_new_included() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let content = root.join("content");
+        fs::create_dir_all(&content).unwrap();
+        fs::write(content.join("main.typ"), "= Main\n").unwrap();
+
+        let mut extra = toml::Table::new();
+        extra.insert(
+            "vertebrae".to_string(),
+            toml::Value::Array(vec![toml::Value::String("*.typ".to_string())]),
+        );
+        let spine = Spine {
+            extra,
+            ..Default::default()
+        };
+        let mut plugin_sections = HashMap::new();
+        plugin_sections.insert(
+            "pdf".to_string(),
+            rheo_core::PluginSection {
+                spine: Some(spine),
+                ..Default::default()
+            },
+        );
+
+        let project = ProjectConfig {
+            root: root.to_path_buf(),
+            name: "test".into(),
+            config: rheo_core::RheoConfig {
+                version: ManifestVersion::parse("0.3.0").unwrap(),
+                content_dir: Some("content".into()),
+                plugin_sections,
+                ..Default::default()
+            },
+            typ_files: vec![content.join("main.typ")],
+            mode: rheo_core::config::project::ProjectMode::Directory,
+            config_path: Some(root.join("rheo.toml")),
+        };
+        let toml_path = root.join("rheo.toml");
+        fs::write(
+            &toml_path,
+            "version = \"0.3.0\"\ncontent_dir = \"content\"\n\n[pdf.spine]\nvertebrae = [\"*.typ\"]\n",
+        )
+        .unwrap();
+
+        migrate_vertebrae_to_exclude(&project, &toml_path, true).unwrap();
+        let updated = fs::read_to_string(&toml_path).unwrap();
+        assert!(!updated.contains("vertebrae"), "{updated}");
+        assert!(!updated.contains("exclude"), "{updated}");
     }
 
     #[test]

--- a/crates/cli/src/migrate.rs
+++ b/crates/cli/src/migrate.rs
@@ -124,7 +124,11 @@ fn migrate_link_syntax(project: &ProjectConfig, apply: bool) -> Result<()> {
         ext: "html".into(),
         format: "html".into(),
     };
-    let spine = VirtualSpine::build(SpineScan::flat(&typ_files, &content_dir), &project.root, layout)?;
+    let spine = VirtualSpine::build(
+        SpineScan::flat(&typ_files, &content_dir),
+        &project.root,
+        layout,
+    )?;
 
     // Canonical absolute source path -> label to emit.
     // The primary handle is always unique: bare (`intro`) for root-level files,

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -12,7 +12,7 @@ use crate::config::output::OutputConfig;
 use crate::config::project::{ProjectConfig, ProjectMode};
 use crate::diagnostics::results::CompilationResults;
 use crate::plugins::{CastVertebra, FormatPlugin, PluginContext, SpineOptions, spine_layout_for};
-use crate::reticulate::spine::VirtualSpine;
+use crate::reticulate::spine::{SpineScan, VirtualSpine};
 use crate::world::RheoWorld;
 use crate::{Result, RheoError};
 use std::path::{Path, PathBuf};
@@ -172,38 +172,36 @@ impl Build {
         plugin_section: &PluginSection,
         content_dir: &Path,
     ) -> Result<(VirtualSpine, typst_bundle::VirtualFs)> {
-        // Resolve spine options.
-        let spine_cfg = plugin_section.spine.as_ref();
-        let spine = SpineOptions {
-            title: spine_cfg.and_then(|s| s.title.clone()),
-            vertebrae: spine_cfg.map(|s| s.vertebrae.clone()).unwrap_or_default(),
-        };
+        // Effective spine config: a per-format [plugin.spine] fully replaces the
+        // global [spine]; with neither, the spine is a pure directory scan.
+        let spine_cfg = plugin_section
+            .spine
+            .as_ref()
+            .or(self.project.config.spine.as_ref());
+        let exclude = spine_cfg.map(|s| s.exclude.clone()).unwrap_or_default();
+        let sections = spine_cfg.map(|s| s.section.clone()).unwrap_or_default();
 
-        // Build VirtualSpine from plugin's declared layout + project context.
         let layout = spine_layout_for(plugin.spine_layout_kind(), plugin, &self.project.name);
-        let spine_files = match self.project.mode {
-            ProjectMode::SingleFile => vec![self.project.typ_files[0].clone()],
+
+        // Base spine = directory scan under content_dir, customized by the two
+        // knobs (exclude, then section layering). A single-file project is a
+        // one-node flat spine.
+        let scan = match self.project.mode {
+            ProjectMode::SingleFile => {
+                SpineScan::flat(&[self.project.typ_files[0].clone()], content_dir)
+            }
             ProjectMode::Directory => {
-                // When content_dir is explicit in config, vertebrae patterns are
-                // relative to it. When auto-detected or absent, vertebrae are
-                // project-root-relative (users write "content/**" explicitly).
-                let explicit_content_dir =
-                    self.project.config.resolve_content_dir(&self.project.root);
-                let generate_root = explicit_content_dir
-                    .as_deref()
-                    .unwrap_or(&self.project.root);
-                spine.generate(generate_root)?
+                SpineScan::run(content_dir, &exclude)?.apply_sections(content_dir, &sections)?
             }
         };
 
         debug!(
             plugin = plugin.name(),
-            files = spine_files.len(),
+            files = scan.files.len(),
             "building virtual spine"
         );
 
-        let virtual_spine =
-            VirtualSpine::build(&spine_files, content_dir, &self.project.root, layout)?;
+        let virtual_spine = VirtualSpine::build(scan, &self.project.root, layout)?;
         virtual_spine.check_output_collisions()?;
 
         let moulded = virtual_spine.mould();
@@ -373,10 +371,16 @@ impl Build {
 
             // `spine` (used by PluginContext below) is re-derived here; `compile_spine`
             // resolves its own copy internally to build the VirtualSpine.
-            let spine_cfg = plugin_section.spine.as_ref();
+            // Plugins read `ctx.spine.title` (e.g. the HTML feed title). Resolve
+            // it with the same precedence as the spine itself: per-format
+            // [plugin.spine] title, else the global [spine] title.
+            let spine_cfg = plugin_section
+                .spine
+                .as_ref()
+                .or(self.project.config.spine.as_ref());
             let spine = SpineOptions {
                 title: spine_cfg.and_then(|s| s.title.clone()),
-                vertebrae: spine_cfg.map(|s| s.vertebrae.clone()).unwrap_or_default(),
+                vertebrae: Vec::new(),
             };
 
             let ctx = PluginContext {

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -172,15 +172,24 @@ impl Build {
         plugin_section: &PluginSection,
         content_dir: &Path,
     ) -> Result<(VirtualSpine, typst_bundle::VirtualFs)> {
-        // Effective spine config: a per-format [plugin.spine] fully replaces the
-        // global [spine]; with neither, the spine is a pure directory scan.
-        let spine_cfg = plugin_section
-            .spine
-            .as_ref()
-            .or(self.project.config.spine.as_ref());
-        let exclude = spine_cfg.map(|s| s.exclude.clone()).unwrap_or_default();
-        let sections = spine_cfg.map(|s| s.section.clone()).unwrap_or_default();
-        let title = spine_cfg.and_then(|s| s.title.clone());
+        // Effective spine config: each field on a per-format [plugin.spine]
+        // falls back to the global [spine] independently when unset, rather
+        // than the per-format table's mere presence blanking every global
+        // spine key at once (a footgun since fixed — rheo-9vl.2: e.g. setting
+        // only `[pdf.spine] title` used to silently drop a global `exclude`).
+        let plugin_spine = plugin_section.spine.as_ref();
+        let global_spine = self.project.config.spine.as_ref();
+        let exclude = plugin_spine
+            .and_then(|s| s.exclude.clone())
+            .or_else(|| global_spine.and_then(|s| s.exclude.clone()))
+            .unwrap_or_default();
+        let sections = plugin_spine
+            .and_then(|s| s.section.clone())
+            .or_else(|| global_spine.and_then(|s| s.section.clone()))
+            .unwrap_or_default();
+        let title = plugin_spine
+            .and_then(|s| s.title.clone())
+            .or_else(|| global_spine.and_then(|s| s.title.clone()));
 
         let layout = spine_layout_for(plugin.spine_layout_kind(), plugin, &self.project.name);
 

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -180,6 +180,7 @@ impl Build {
             .or(self.project.config.spine.as_ref());
         let exclude = spine_cfg.map(|s| s.exclude.clone()).unwrap_or_default();
         let sections = spine_cfg.map(|s| s.section.clone()).unwrap_or_default();
+        let title = spine_cfg.and_then(|s| s.title.clone());
 
         let layout = spine_layout_for(plugin.spine_layout_kind(), plugin, &self.project.name);
 
@@ -201,7 +202,8 @@ impl Build {
             "building virtual spine"
         );
 
-        let virtual_spine = VirtualSpine::build(scan, &self.project.root, layout)?;
+        let virtual_spine =
+            VirtualSpine::build(scan, &self.project.root, layout)?.with_title(title);
         virtual_spine.check_output_collisions()?;
 
         let moulded = virtual_spine.mould();
@@ -369,20 +371,10 @@ impl Build {
             let (virtual_spine, virtual_fs) =
                 self.compile_spine(plugin.as_ref(), plugin_section, &content_dir)?;
 
-            // Resolve the effective spine title, exposed to plugins as
-            // `ctx.spine_title`, with the same precedence as the spine itself:
-            // per-format [plugin.spine] title, else the global [spine] title.
-            let spine_cfg = plugin_section
-                .spine
-                .as_ref()
-                .or(self.project.config.spine.as_ref());
-            let spine_title = spine_cfg.and_then(|s| s.title.as_deref());
-
             let ctx = PluginContext {
                 project: &self.project,
                 output_dir: &plugin_output_dir,
                 spine: &virtual_spine,
-                spine_title,
                 config: plugin_section,
                 assets: &resolved_assets,
                 font_dirs: &self.font_dirs,

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -381,6 +381,7 @@ impl Build {
             let ctx = PluginContext {
                 project: &self.project,
                 output_dir: &plugin_output_dir,
+                spine: &virtual_spine,
                 spine_title,
                 config: plugin_section,
                 assets: &resolved_assets,

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -11,7 +11,7 @@ use crate::config::PluginSection;
 use crate::config::output::OutputConfig;
 use crate::config::project::{ProjectConfig, ProjectMode};
 use crate::diagnostics::results::CompilationResults;
-use crate::plugins::{CastVertebra, FormatPlugin, PluginContext, SpineOptions, spine_layout_for};
+use crate::plugins::{CastVertebra, FormatPlugin, PluginContext, spine_layout_for};
 use crate::reticulate::spine::{SpineScan, VirtualSpine};
 use crate::world::RheoWorld;
 use crate::{Result, RheoError};
@@ -369,24 +369,19 @@ impl Build {
             let (virtual_spine, virtual_fs) =
                 self.compile_spine(plugin.as_ref(), plugin_section, &content_dir)?;
 
-            // `spine` (used by PluginContext below) is re-derived here; `compile_spine`
-            // resolves its own copy internally to build the VirtualSpine.
-            // Plugins read `ctx.spine.title` (e.g. the HTML feed title). Resolve
-            // it with the same precedence as the spine itself: per-format
-            // [plugin.spine] title, else the global [spine] title.
+            // Resolve the effective spine title, exposed to plugins as
+            // `ctx.spine_title`, with the same precedence as the spine itself:
+            // per-format [plugin.spine] title, else the global [spine] title.
             let spine_cfg = plugin_section
                 .spine
                 .as_ref()
                 .or(self.project.config.spine.as_ref());
-            let spine = SpineOptions {
-                title: spine_cfg.and_then(|s| s.title.clone()),
-                vertebrae: Vec::new(),
-            };
+            let spine_title = spine_cfg.and_then(|s| s.title.as_deref());
 
             let ctx = PluginContext {
                 project: &self.project,
                 output_dir: &plugin_output_dir,
-                spine: &spine,
+                spine_title,
                 config: plugin_section,
                 assets: &resolved_assets,
                 font_dirs: &self.font_dirs,

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -22,13 +22,21 @@ pub struct Spine {
 
     /// Glob patterns (relative to content_dir) for files/folders to omit from
     /// the directory-scanned spine.
+    ///
+    /// `None` when unset in this table (as opposed to `Some(vec![])`, an
+    /// explicit empty list) so a per-format `[plugin.spine]` that doesn't set
+    /// `exclude` falls back to the global `[spine] exclude` field-by-field,
+    /// rather than a per-format table's mere presence blanking every global
+    /// spine key at once (rheo-9vl.2).
     #[serde(default)]
-    pub exclude: Vec<String>,
+    pub exclude: Option<Vec<String>>,
 
     /// Virtual-directory layering over flat files (knob 2). Each section groups
     /// matched files under a virtual subdirectory without moving them on disk.
+    ///
+    /// `None` when unset, for the same per-field fallback reason as `exclude`.
     #[serde(default)]
-    pub section: Vec<SpineSection>,
+    pub section: Option<Vec<SpineSection>>,
 
     /// Unrecognized keys, captured so [`validation`](super::validation) can warn
     /// when a field retired from `Spine` in a past version (e.g. the removed
@@ -743,11 +751,15 @@ mod tests {
         );
         let config = parse(&toml);
         let spine = config.spine.as_ref().unwrap();
-        assert_eq!(spine.exclude, vec!["drafts/**", "*.tmp.typ"]);
-        assert_eq!(spine.section.len(), 1);
-        assert_eq!(spine.section[0].name, "guides");
-        assert_eq!(spine.section[0].section.len(), 1);
-        assert_eq!(spine.section[0].section[0].name, "advanced");
+        assert_eq!(
+            spine.exclude.clone().unwrap(),
+            vec!["drafts/**", "*.tmp.typ"]
+        );
+        let sections = spine.section.clone().unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].name, "guides");
+        assert_eq!(sections[0].section.len(), 1);
+        assert_eq!(sections[0].section[0].name, "advanced");
         assert!(!config.plugin_sections.contains_key("spine"));
     }
 
@@ -765,10 +777,11 @@ mod tests {
         );
         let config = parse(&toml);
         let spine = config.spine_for_plugin("pdf").unwrap();
-        assert_eq!(spine.exclude, vec!["scratch/**"]);
-        assert_eq!(spine.section.len(), 1);
-        assert_eq!(spine.section[0].name, "appendix");
-        assert_eq!(spine.section[0].include, vec!["appendix/*.typ"]);
+        assert_eq!(spine.exclude.clone().unwrap(), vec!["scratch/**"]);
+        let sections = spine.section.clone().unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].name, "appendix");
+        assert_eq!(sections[0].include, vec!["appendix/*.typ"]);
     }
 
     #[test]
@@ -779,8 +792,8 @@ mod tests {
         let config = parse(&toml);
         let spine = config.spine_for_plugin("pdf").unwrap();
         assert!(spine.extra.contains_key("vertebrae"));
-        assert!(spine.exclude.is_empty());
-        assert!(spine.section.is_empty());
+        assert!(spine.exclude.is_none());
+        assert!(spine.section.is_none());
     }
 
     #[test]

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -25,6 +25,32 @@ pub struct Spine {
     /// Empty = auto-discover all .typ files.
     #[serde(default)]
     pub vertebrae: Vec<String>,
+
+    /// Glob patterns (relative to content_dir) for files/folders to omit from
+    /// the directory-scanned spine.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+
+    /// Virtual-directory layering over flat files (knob 2). Each section groups
+    /// matched files under a virtual subdirectory without moving them on disk.
+    #[serde(default)]
+    pub section: Vec<SpineSection>,
+}
+
+/// A virtual directory in the spine: groups flat files under a named node,
+/// behaving like an on-disk subdirectory. Nests to arbitrary depth via `section`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpineSection {
+    /// Slug — the node's handle segment and sibling sort key (like a dir name).
+    pub name: String,
+    /// Display title; when absent, derived from `name`.
+    pub title: Option<String>,
+    /// Glob patterns (relative to content_dir) for files pulled under this section.
+    #[serde(default)]
+    pub include: Vec<String>,
+    /// Nested virtual directories.
+    #[serde(default)]
+    pub section: Vec<SpineSection>,
 }
 
 /// Asset configuration for `[plugin_name.assets]` in rheo.toml.
@@ -131,6 +157,9 @@ pub struct RheoConfig {
     /// Per-plugin configuration sections, keyed by plugin name.
     /// Built from `[html]`, `[pdf]`, `[epub]` (and any other) table sections.
     pub plugin_sections: HashMap<String, PluginSection>,
+
+    /// Global spine configuration (applies when no per-plugin spine is set).
+    pub spine: Option<Spine>,
 }
 
 impl Default for RheoConfig {
@@ -143,6 +172,7 @@ impl Default for RheoConfig {
             copy: vec![],
             font_dirs: vec![],
             plugin_sections: HashMap::new(),
+            spine: None,
         }
     }
 }
@@ -166,7 +196,11 @@ pub struct RheoConfigRaw {
 impl TryFrom<RheoConfigRaw> for RheoConfig {
     type Error = toml::de::Error;
 
-    fn try_from(raw: RheoConfigRaw) -> std::result::Result<Self, Self::Error> {
+    fn try_from(mut raw: RheoConfigRaw) -> std::result::Result<Self, Self::Error> {
+        let spine: Option<Spine> = match raw.extra.remove("spine") {
+            Some(value) => value.try_into()?,
+            None => None,
+        };
         let mut plugin_sections = HashMap::new();
         for (key, value) in raw.extra {
             if let toml::Value::Table(_) = &value {
@@ -183,6 +217,7 @@ impl TryFrom<RheoConfigRaw> for RheoConfig {
             copy: raw.copy,
             font_dirs: raw.font_dirs,
             plugin_sections,
+            spine,
         })
     }
 }
@@ -723,5 +758,72 @@ mod tests {
         assert_eq!(pairs[0].0.dest.as_deref(), Some("subdir"));
         assert_eq!(pairs[1].1, "two.js");
         assert!(pairs[1].0.dest.is_none());
+    }
+
+    #[test]
+    fn test_global_spine_exclude_and_nested_sections() {
+        let toml = versioned_toml(
+            r#"
+        [spine]
+        exclude = ["drafts/**", "*.tmp.typ"]
+
+        [[spine.section]]
+        name = "guides"
+
+        [[spine.section.section]]
+        name = "advanced"
+        "#,
+        );
+        let config = parse(&toml);
+        let spine = config.spine.as_ref().unwrap();
+        assert_eq!(spine.exclude, vec!["drafts/**", "*.tmp.typ"]);
+        assert_eq!(spine.section.len(), 1);
+        assert_eq!(spine.section[0].name, "guides");
+        assert_eq!(spine.section[0].section.len(), 1);
+        assert_eq!(spine.section[0].section[0].name, "advanced");
+        assert!(!config.plugin_sections.contains_key("spine"));
+    }
+
+    #[test]
+    fn test_pdf_spine_exclude_and_section() {
+        let toml = versioned_toml(
+            r#"
+        [pdf.spine]
+        exclude = ["scratch/**"]
+
+        [[pdf.spine.section]]
+        name = "appendix"
+        include = ["appendix/*.typ"]
+        "#,
+        );
+        let config = parse(&toml);
+        let spine = config.spine_for_plugin("pdf").unwrap();
+        assert_eq!(spine.exclude, vec!["scratch/**"]);
+        assert_eq!(spine.section.len(), 1);
+        assert_eq!(spine.section[0].name, "appendix");
+        assert_eq!(spine.section[0].include, vec!["appendix/*.typ"]);
+    }
+
+    #[test]
+    fn test_legacy_pdf_spine_without_exclude_or_section() {
+        let toml = versioned_toml("[pdf.spine]\nvertebrae = [\"cover.typ\", \"chapters/*.typ\"]");
+        let config = parse(&toml);
+        let spine = config.spine_for_plugin("pdf").unwrap();
+        assert_eq!(spine.vertebrae, vec!["cover.typ", "chapters/*.typ"]);
+        assert!(spine.exclude.is_empty());
+        assert!(spine.section.is_empty());
+    }
+
+    #[test]
+    fn test_spine_section_title_defaults_to_none() {
+        let toml = r#"
+        name = "guides"
+        include = ["guides/*.typ"]
+    "#;
+        let section: SpineSection = toml::from_str(toml).expect("parse failed");
+        assert_eq!(section.name, "guides");
+        assert!(section.title.is_none());
+        assert!(section.include.len() == 1);
+        assert!(section.section.is_empty());
     }
 }

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -12,19 +12,13 @@ pub mod validation;
 pub use manifest_version::ManifestVersion;
 use validation::ValidateConfig;
 
-/// Spine configuration from `rheo.toml`: glob patterns and title.
+/// Spine configuration from `rheo.toml`: directory-scan knobs and title.
 ///
 /// All format plugins share this single config type.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Spine {
     /// Title for the combined output document, when applicable.
     pub title: Option<String>,
-
-    /// Glob patterns for files to include, evaluated relative to content_dir.
-    /// Results are sorted lexicographically within each pattern.
-    /// Empty = auto-discover all .typ files.
-    #[serde(default)]
-    pub vertebrae: Vec<String>,
 
     /// Glob patterns (relative to content_dir) for files/folders to omit from
     /// the directory-scanned spine.
@@ -35,6 +29,13 @@ pub struct Spine {
     /// matched files under a virtual subdirectory without moving them on disk.
     #[serde(default)]
     pub section: Vec<SpineSection>,
+
+    /// Unrecognized keys, captured so [`validation`](super::validation) can warn
+    /// when a field retired from `Spine` in a past version (e.g. the removed
+    /// `vertebrae` glob list) is still set in an older `rheo.toml`, rather than
+    /// silently dropping it.
+    #[serde(flatten, default)]
+    pub extra: toml::Table,
 }
 
 /// A virtual directory in the spine: groups flat files under a named node,
@@ -503,63 +504,29 @@ mod tests {
     }
 
     #[test]
-    fn test_pdf_spine_parses_title_and_vertebrae() {
+    fn test_pdf_spine_parses_title() {
         // A legacy `merge` key (removed) is silently ignored, so old configs
-        // still parse; title and vertebrae are read as usual.
-        let toml = versioned_toml(
-            "[pdf.spine]\ntitle = \"My Book\"\nvertebrae = [\"cover.typ\", \"chapters/*.typ\"]\nmerge = true",
-        );
+        // still parse; title is read as usual.
+        let toml = versioned_toml("[pdf.spine]\ntitle = \"My Book\"\nmerge = true");
         let config = parse(&toml);
         let spine = config.spine_for_plugin("pdf").unwrap();
         assert_eq!(spine.title.as_ref().unwrap(), "My Book");
-        assert_eq!(spine.vertebrae, vec!["cover.typ", "chapters/*.typ"]);
     }
 
     #[test]
     fn test_epub_spine() {
-        let toml = versioned_toml(
-            "[epub.spine]\ntitle = \"My EPUB\"\nvertebrae = [\"intro.typ\", \"chapter*.typ\", \"outro.typ\"]",
-        );
+        let toml = versioned_toml("[epub.spine]\ntitle = \"My EPUB\"");
         let config = parse(&toml);
         let spine = config.spine_for_plugin("epub").unwrap();
         assert_eq!(spine.title.as_deref().unwrap(), "My EPUB");
-        assert_eq!(
-            spine.vertebrae,
-            vec!["intro.typ", "chapter*.typ", "outro.typ"]
-        );
     }
 
     #[test]
     fn test_html_spine() {
-        let toml = versioned_toml(
-            "[html.spine]\ntitle = \"My Website\"\nvertebrae = [\"index.typ\", \"about.typ\"]",
-        );
+        let toml = versioned_toml("[html.spine]\ntitle = \"My Website\"");
         let config = parse(&toml);
         let spine = config.spine_for_plugin("html").unwrap();
         assert_eq!(spine.title.as_ref().unwrap(), "My Website");
-        assert_eq!(spine.vertebrae, vec!["index.typ", "about.typ"]);
-    }
-
-    #[test]
-    fn test_spine_empty_vertebrae() {
-        let toml = versioned_toml("[epub.spine]\ntitle = \"Single File Book\"\nvertebrae = []");
-        let config = parse(&toml);
-        let spine = config.spine_for_plugin("epub").unwrap();
-        assert_eq!(spine.title.as_deref().unwrap(), "Single File Book");
-        assert!(spine.vertebrae.is_empty());
-    }
-
-    #[test]
-    fn test_spine_complex_glob_patterns() {
-        let toml = versioned_toml(
-            "[pdf.spine]\ntitle = \"Complex Book\"\nvertebrae = [\"frontmatter/**/*.typ\", \"chapters/**/ch*.typ\", \"appendix.typ\"]\nmerge = true",
-        );
-        let config = parse(&toml);
-        let spine = config.spine_for_plugin("pdf").unwrap();
-        assert_eq!(spine.vertebrae.len(), 3);
-        assert_eq!(spine.vertebrae[0], "frontmatter/**/*.typ");
-        assert_eq!(spine.vertebrae[1], "chapters/**/ch*.typ");
-        assert_eq!(spine.vertebrae[2], "appendix.typ");
     }
 
     #[test]
@@ -805,11 +772,13 @@ mod tests {
     }
 
     #[test]
-    fn test_legacy_pdf_spine_without_exclude_or_section() {
+    fn test_legacy_vertebrae_only_config_still_parses() {
+        // A legacy config setting only the retired `vertebrae` key still
+        // parses (captured in `extra`, not a typed field) rather than erroring.
         let toml = versioned_toml("[pdf.spine]\nvertebrae = [\"cover.typ\", \"chapters/*.typ\"]");
         let config = parse(&toml);
         let spine = config.spine_for_plugin("pdf").unwrap();
-        assert_eq!(spine.vertebrae, vec!["cover.typ", "chapters/*.typ"]);
+        assert!(spine.extra.contains_key("vertebrae"));
         assert!(spine.exclude.is_empty());
         assert!(spine.section.is_empty());
     }

--- a/crates/core/src/config/project.rs
+++ b/crates/core/src/config/project.rs
@@ -284,7 +284,7 @@ mod tests {
         fs::write(
             &config_path,
             format!(
-                "version = \"{}\"\n\n[epub.spine]\ntitle = \"Custom Title\"\nvertebrae = [\"custom.typ\"]\n",
+                "version = \"{}\"\n\n[epub.spine]\ntitle = \"Custom Title\"\n",
                 env!("CARGO_PKG_VERSION")
             ),
         )
@@ -295,7 +295,6 @@ mod tests {
         let section = project.config.plugin_section("epub");
         let spine = section.spine.unwrap();
         assert_eq!(spine.title.as_deref().unwrap(), "Custom Title");
-        assert_eq!(spine.vertebrae, vec!["custom.typ"]);
     }
 
     #[test]

--- a/crates/core/src/config/validation.rs
+++ b/crates/core/src/config/validation.rs
@@ -60,6 +60,7 @@ mod tests {
         let spine = Spine {
             title: Some("Test".to_string()),
             vertebrae: vec![],
+            ..Default::default()
         };
         assert!(spine.validate().is_ok());
     }
@@ -69,6 +70,7 @@ mod tests {
         let spine = Spine {
             title: Some("Test".to_string()),
             vertebrae: vec!["*.typ".to_string(), "chapters/**/*.typ".to_string()],
+            ..Default::default()
         };
         assert!(spine.validate().is_ok());
     }
@@ -78,6 +80,7 @@ mod tests {
         let spine = Spine {
             title: Some("Test".to_string()),
             vertebrae: vec!["[invalid".to_string()],
+            ..Default::default()
         };
         let result = spine.validate();
         assert!(result.is_err());

--- a/crates/core/src/config/validation.rs
+++ b/crates/core/src/config/validation.rs
@@ -41,8 +41,13 @@ impl ValidateConfig for RheoConfig {
 /// warning: an inert key doesn't corrupt the build, but silently ignoring it
 /// entirely risks a project's spine membership changing without the author
 /// noticing (see https://rheo.ohrg.org/spines for the current model).
-fn warn_on_vertebrae(vertebrae: &[String]) {
-    if !vertebrae.is_empty() {
+///
+/// This is a one-off, named after the single retired field we currently have.
+/// If a second retired-key warning is ever needed, generalize both of these
+/// into a `RetiredKey` trait (key name + replacement message) rather than
+/// adding another standalone function like this one.
+fn warn_on_vertebrae(extra: &toml::Table) {
+    if extra.contains_key("vertebrae") {
         warn!(
             "`vertebrae` no longer has any effect as of rheo 0.5.0 — spine membership and \
              order now come from a directory scan plus `[spine] exclude` / `[[spine.section]]`. \
@@ -53,7 +58,7 @@ fn warn_on_vertebrae(vertebrae: &[String]) {
 
 impl ValidateConfig for Spine {
     fn validate(&self) -> Result<()> {
-        warn_on_vertebrae(&self.vertebrae);
+        warn_on_vertebrae(&self.extra);
 
         Ok(())
     }
@@ -67,7 +72,6 @@ mod tests {
     fn test_universal_spine_validate_empty() {
         let spine = Spine {
             title: Some("Test".to_string()),
-            vertebrae: vec![],
             ..Default::default()
         };
         assert!(spine.validate().is_ok());
@@ -75,11 +79,17 @@ mod tests {
 
     #[test]
     fn test_universal_spine_validate_ignores_now_inert_vertebrae() {
-        // `vertebrae` no longer affects the build, so even a glob-invalid entry
-        // is just a (untested-here) warning, not a validation error.
+        // `vertebrae` no longer affects the build, so its presence (even a
+        // glob-invalid entry) is just a (untested-here) warning, not a
+        // validation error.
+        let mut extra = toml::Table::new();
+        extra.insert(
+            "vertebrae".to_string(),
+            toml::Value::Array(vec![toml::Value::String("[invalid".to_string())]),
+        );
         let spine = Spine {
             title: Some("Test".to_string()),
-            vertebrae: vec!["[invalid".to_string()],
+            extra,
             ..Default::default()
         };
         assert!(spine.validate().is_ok());

--- a/crates/core/src/config/validation.rs
+++ b/crates/core/src/config/validation.rs
@@ -33,19 +33,27 @@ impl ValidateConfig for RheoConfig {
     }
 }
 
-/// Validate glob patterns in a vertebrae list.
-fn validate_vertebrae(vertebrae: &[String]) -> Result<()> {
-    for pattern in vertebrae {
-        glob::Pattern::new(pattern).map_err(|e| {
-            RheoError::project_config(format!("invalid glob pattern '{}': {}", pattern, e))
-        })?;
+/// Warn when a `rheo.toml` still sets the retired `vertebrae` glob list.
+///
+/// Since the structured-spine directory scan landed, `vertebrae` has no effect
+/// on spine membership or order — that now comes from the directory scan plus
+/// `[spine] exclude` / `[[spine.section]]`. Unlike a hard error, this stays a
+/// warning: an inert key doesn't corrupt the build, but silently ignoring it
+/// entirely risks a project's spine membership changing without the author
+/// noticing (see https://rheo.ohrg.org/spines for the current model).
+fn warn_on_vertebrae(vertebrae: &[String]) {
+    if !vertebrae.is_empty() {
+        warn!(
+            "`vertebrae` no longer has any effect as of rheo 0.5.0 — spine membership and \
+             order now come from a directory scan plus `[spine] exclude` / `[[spine.section]]`. \
+             See https://rheo.ohrg.org/spines for the current model."
+        );
     }
-    Ok(())
 }
 
 impl ValidateConfig for Spine {
     fn validate(&self) -> Result<()> {
-        validate_vertebrae(&self.vertebrae)?;
+        warn_on_vertebrae(&self.vertebrae);
 
         Ok(())
     }
@@ -66,26 +74,15 @@ mod tests {
     }
 
     #[test]
-    fn test_universal_spine_validate_valid_patterns() {
-        let spine = Spine {
-            title: Some("Test".to_string()),
-            vertebrae: vec!["*.typ".to_string(), "chapters/**/*.typ".to_string()],
-            ..Default::default()
-        };
-        assert!(spine.validate().is_ok());
-    }
-
-    #[test]
-    fn test_universal_spine_validate_invalid_pattern() {
+    fn test_universal_spine_validate_ignores_now_inert_vertebrae() {
+        // `vertebrae` no longer affects the build, so even a glob-invalid entry
+        // is just a (untested-here) warning, not a validation error.
         let spine = Spine {
             title: Some("Test".to_string()),
             vertebrae: vec!["[invalid".to_string()],
             ..Default::default()
         };
-        let result = spine.validate();
-        assert!(result.is_err());
-        let err_msg = format!("{}", result.unwrap_err());
-        assert!(err_msg.contains("invalid glob pattern"));
+        assert!(spine.validate().is_ok());
     }
 
     #[test]
@@ -124,20 +121,13 @@ mod tests {
     }
 
     #[test]
-    fn test_rheo_config_rejects_invalid_glob_in_section() {
+    fn test_rheo_config_ignores_now_inert_vertebrae_in_section() {
         let toml = format!(
             "version = \"{}\"\n[pdf.spine]\nvertebrae = [\"[invalid\"]",
             env!("CARGO_PKG_VERSION")
         );
         let raw: crate::config::RheoConfigRaw = toml::from_str(&toml).unwrap();
         let config = RheoConfig::try_from(raw).unwrap();
-        let result = config.validate();
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("invalid glob pattern")
-        );
+        assert!(config.validate().is_ok());
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -35,7 +35,7 @@ pub use config::{AssetsField, PluginAssets, PluginSection, Spine};
 pub use parser::RheoValue;
 pub use plugins::{
     AssetConfig, CastVertebra, FormatInitTemplate, FormatPlugin, OpenHandle, PackageAssets,
-    PluginContext, ResolvedPackage, ServerHandle, SpineLayoutKind, SpineOptions, TypstFormat,
+    PluginContext, ResolvedPackage, ServerHandle, SpineLayoutKind, TypstFormat,
 };
 
 // HTML/PDF export utilities

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::PluginSection;
 use crate::config::project::ProjectConfig;
-use crate::reticulate::spine::SpineLayout;
+use crate::reticulate::spine::{SpineLayout, VirtualSpine};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::info;
@@ -147,15 +147,16 @@ pub struct PluginContext<'a> {
     pub project: &'a ProjectConfig,
     /// Plugin output directory (e.g., `build/html/`). Write outputs here.
     pub output_dir: &'a PathBuf,
+    /// The resolved spine — same tree and flat vertebra list as the Typst-side
+    /// `rheo-context` (`spine`/`spine-flat`), available on the Rust side too.
+    /// `compile()`'s `outputs: &[CastVertebra]` parameter is a separate,
+    /// already-cast view of each output's title/date/vars; use `spine` for
+    /// the tree structure and cross-vertebra queries, `outputs` for per-output
+    /// compiled bytes.
+    pub spine: &'a VirtualSpine,
     /// Resolved spine title, when configured (per-format `[plugin.spine] title`
-    /// or the global `[spine] title`).
-    ///
-    /// This is the only piece of the Typst-side `rheo-context` a plugin reads
-    /// through `PluginContext` — the rest (the spine tree, the flat page list)
-    /// isn't duplicated here. `compile()`'s `outputs: &[CastVertebra]` parameter
-    /// is the Rust-side equivalent of the flat page list, carrying each
-    /// output's title/date/vars directly, so plugins read spine data from
-    /// there rather than from a second copy on `PluginContext`.
+    /// or the global `[spine] title`). Distinct from any vertebra's own title —
+    /// this is the combined-document/feed-level title override.
     pub spine_title: Option<&'a str>,
     /// Full parsed plugin section from rheo.toml (or default if not configured).
     ///

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -148,16 +148,14 @@ pub struct PluginContext<'a> {
     /// Plugin output directory (e.g., `build/html/`). Write outputs here.
     pub output_dir: &'a PathBuf,
     /// The resolved spine — same tree and flat vertebra list as the Typst-side
-    /// `rheo-context` (`spine`/`spine-flat`), available on the Rust side too.
-    /// `compile()`'s `outputs: &[CastVertebra]` parameter is a separate,
-    /// already-cast view of each output's title/date/vars; use `spine` for
-    /// the tree structure and cross-vertebra queries, `outputs` for per-output
-    /// compiled bytes.
+    /// `rheo-context` (`spine`/`spine-flat`), available on the Rust side too,
+    /// plus the resolved combined-document/feed title (`spine.title`, distinct
+    /// from any individual vertebra's own title). `compile()`'s
+    /// `outputs: &[CastVertebra]` parameter is a separate, already-cast view of
+    /// each output's title/date/vars; use `spine` for the tree structure,
+    /// cross-vertebra queries, and the resolved title, `outputs` for
+    /// per-output compiled bytes.
     pub spine: &'a VirtualSpine,
-    /// Resolved spine title, when configured (per-format `[plugin.spine] title`
-    /// or the global `[spine] title`). Distinct from any vertebra's own title —
-    /// this is the combined-document/feed-level title override.
-    pub spine_title: Option<&'a str>,
     /// Full parsed plugin section from rheo.toml (or default if not configured).
     ///
     /// # Reading format-specific configuration

--- a/crates/core/src/plugins/mod.rs
+++ b/crates/core/src/plugins/mod.rs
@@ -33,13 +33,6 @@ pub enum OpenHandle {
 
 use crate::config::PluginAssets;
 
-/// Standardized spine options resolved by rheo core before calling compile().
-#[derive(Debug, Clone)]
-pub struct SpineOptions {
-    pub title: Option<String>,
-    pub vertebrae: Vec<String>,
-}
-
 /// Declares an additional non-Typst input file needed from the project directory.
 #[derive(Debug, Clone)]
 pub struct AssetConfig {
@@ -154,8 +147,16 @@ pub struct PluginContext<'a> {
     pub project: &'a ProjectConfig,
     /// Plugin output directory (e.g., `build/html/`). Write outputs here.
     pub output_dir: &'a PathBuf,
-    /// Resolved spine options (title, vertebrae patterns).
-    pub spine: &'a SpineOptions,
+    /// Resolved spine title, when configured (per-format `[plugin.spine] title`
+    /// or the global `[spine] title`).
+    ///
+    /// This is the only piece of the Typst-side `rheo-context` a plugin reads
+    /// through `PluginContext` — the rest (the spine tree, the flat page list)
+    /// isn't duplicated here. `compile()`'s `outputs: &[CastVertebra]` parameter
+    /// is the Rust-side equivalent of the flat page list, carrying each
+    /// output's title/date/vars directly, so plugins read spine data from
+    /// there rather than from a second copy on `PluginContext`.
+    pub spine_title: Option<&'a str>,
     /// Full parsed plugin section from rheo.toml (or default if not configured).
     ///
     /// # Reading format-specific configuration

--- a/crates/core/src/reticulate/mod.rs
+++ b/crates/core/src/reticulate/mod.rs
@@ -4,4 +4,4 @@ pub mod spine;
 
 pub use bundle_source::BundleSource;
 pub use mould::{Rewrites, SpineMould, SyntaxRewrite};
-pub use spine::{SpineLayout, Vertebra, VirtualSpine};
+pub use spine::{SpineLayout, SpineScan, Vertebra, VirtualSpine};

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -107,8 +107,7 @@ impl SpineScan {
                     node.collect_indices(&mut indices);
                 }
                 let unique: HashSet<usize> = indices.iter().copied().collect();
-                indices.len() == unique.len()
-                    && indices.iter().all(|&i| i < files.len())
+                indices.len() == unique.len() && indices.iter().all(|&i| i < files.len())
             },
             "spine scan tree indices must be unique and in range"
         );
@@ -183,7 +182,9 @@ impl SpineScan {
         files: &mut Vec<PathBuf>,
     ) -> Result<Vec<SpineNode>> {
         let mut entries: Vec<fs::DirEntry> = fs::read_dir(dir)
-            .map_err(|e| RheoError::project_config(format!("failed to read dir '{}': {}", dir.display(), e)))?
+            .map_err(|e| {
+                RheoError::project_config(format!("failed to read dir '{}': {}", dir.display(), e))
+            })?
             .filter_map(|e| e.ok())
             .collect();
         entries.sort_by_key(|e| e.file_name());
@@ -238,7 +239,9 @@ impl SpineScan {
             .to_string();
 
         let mut entries: Vec<fs::DirEntry> = fs::read_dir(dir)
-            .map_err(|e| RheoError::project_config(format!("failed to read dir '{}': {}", dir.display(), e)))?
+            .map_err(|e| {
+                RheoError::project_config(format!("failed to read dir '{}': {}", dir.display(), e))
+            })?
             .filter_map(|e| e.ok())
             .collect();
         entries.sort_by_key(|e| e.file_name());
@@ -317,13 +320,8 @@ impl SpineScan {
     /// order prefix (e.g. `01-`, `1_`), replace `-`/`_` with spaces, and Title
     /// Case each word.
     fn prettify(dirname: &str) -> String {
-        let digits_end = dirname
-            .find(|c: char| !c.is_ascii_digit())
-            .unwrap_or(0);
-        let stripped = if digits_end > 0
-            && dirname[digits_end..]
-                .starts_with(['-', '_'])
-        {
+        let digits_end = dirname.find(|c: char| !c.is_ascii_digit()).unwrap_or(0);
+        let stripped = if digits_end > 0 && dirname[digits_end..].starts_with(['-', '_']) {
             &dirname[digits_end + 1..]
         } else {
             dirname
@@ -336,8 +334,7 @@ impl SpineScan {
                 let mut chars = w.chars();
                 match chars.next() {
                     Some(first) => {
-                        first.to_uppercase().collect::<String>()
-                            + &chars.as_str().to_lowercase()
+                        first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase()
                     }
                     None => String::new(),
                 }
@@ -356,7 +353,11 @@ impl SpineScan {
     /// lived in `content/guide/`. Only leaf files are movable; a directory
     /// landing page (`index.typ`) stays where it is. Returns `self` unchanged
     /// when there are no sections.
-    pub fn apply_sections(self, content_dir: &Path, sections: &[SpineSection]) -> Result<SpineScan> {
+    pub fn apply_sections(
+        self,
+        content_dir: &Path,
+        sections: &[SpineSection],
+    ) -> Result<SpineScan> {
         if sections.is_empty() {
             return Ok(self);
         }
@@ -490,10 +491,7 @@ impl SpineScan {
             }
 
             for p in matched {
-                let stem = p
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or_default();
+                let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
                 children.push(PathNode {
                     segment: sanitize_handle_segment(stem),
                     title: None,
@@ -840,23 +838,31 @@ impl VirtualSpine {
     /// Per-vertebra `rheo-context` Typst preludes, keyed by include path (`rel_path`).
     ///
     /// Each vertebra is injected with `#let rheo-context = (handle: <its handle>,
-    /// spine: <flat list of every vertebra>)` so package templates can read the
-    /// file's own handle and the whole spine. The `handle` varies per file; the
-    /// `spine` literal is identical across files. The shape is a dictionary so
-    /// attributes can be added later (e.g. by format plugins) without breaking
-    /// consumers.
+    /// spine: <tree>, spine-flat: <flat list>)` so package templates can read the
+    /// file's own handle plus the spine, either as the structural tree or as a
+    /// flat pre-order list. The `handle` varies per file; `spine`/`spine-flat` are
+    /// identical across files. The shape is a dictionary so attributes can be
+    /// added later (e.g. by format plugins) without breaking consumers.
+    ///
+    /// Node key set for `spine` (recursive): `title` (str), `handle` (str or
+    /// `none`), `path` (str or `none`), `children` (array of nodes). A leaf
+    /// (`vertebra: Some`) carries its vertebra's `handle`/`path`/`title`; a group
+    /// node (`vertebra: None`, e.g. a directory or `[[spine.section]]` with no
+    /// landing file) carries `handle: none, path: none` and its own group title.
     ///
     /// `target` is the output-format name (e.g. `"html"`/`"epub"`); when
     /// `Some`, a `target` field is added to the dict, and when `None` (PDF) it
     /// is omitted so consumers fall back to Typst's native `target()`.
     pub fn rheo_context_preludes(&self, target: Option<&str>) -> HashMap<String, String> {
-        let spine = self.spine_data();
+        let spine = self.spine_tree();
+        let spine_flat = self.spine_flat();
         self.vertebrae
             .iter()
             .map(|v| {
                 let mut fields = vec![
                     ("handle".to_string(), TypstLiteral::str(v.handle.as_str())),
                     ("spine".to_string(), spine.clone()),
+                    ("spine-flat".to_string(), spine_flat.clone()),
                 ];
                 if let Some(t) = target {
                     fields.push(("target".to_string(), TypstLiteral::str(t)));
@@ -871,27 +877,61 @@ impl VirtualSpine {
     /// The file-independent `rheo-context` data exposed via `sys.inputs`.
     ///
     /// `sys.inputs` is global to the whole bundle compile, so it carries only the
-    /// parts of `rheo-context` identical across vertebrae — the spine. Packages
-    /// read `sys.inputs.rheo-context` to detect a rheo build (and reach the shared
-    /// spine) without referencing the per-file `#let rheo-context`, which
-    /// additionally carries this file's `handle`.
+    /// parts of `rheo-context` identical across vertebrae — `spine`/`spine-flat`.
+    /// Packages read `sys.inputs.rheo-context` to detect a rheo build (and reach
+    /// the shared spine) without referencing the per-file `#let rheo-context`,
+    /// which additionally carries this file's `handle`.
     ///
     /// `target` follows the same rule as [`Self::rheo_context_preludes`]: a
     /// `target` field is added when `Some`, omitted for PDF (`None`).
     pub fn global_context(&self, target: Option<&str>) -> TypstLiteral {
-        let mut fields = vec![("spine".to_string(), self.spine_data())];
+        let mut fields = vec![
+            ("spine".to_string(), self.spine_tree()),
+            ("spine-flat".to_string(), self.spine_flat()),
+        ];
         if let Some(t) = target {
             fields.push(("target".to_string(), TypstLiteral::str(t)));
         }
         TypstLiteral::Dict(fields)
     }
 
-    /// The flat spine as a [`TypstLiteral`] array-of-dictionaries: one entry per
-    /// vertebra with `handle`, `path`, and `title`.
-    fn spine_data(&self) -> TypstLiteral {
+    /// The structured spine tree as a [`TypstLiteral`] array of recursive node
+    /// dicts. See [`Self::rheo_context_preludes`] for the node key set.
+    fn spine_tree(&self) -> TypstLiteral {
+        TypstLiteral::Array(self.tree.iter().map(|n| self.node_literal(n)).collect())
+    }
+
+    /// Serialize one [`SpineNode`] (and its descendants) to its `spine` dict shape.
+    fn node_literal(&self, node: &SpineNode) -> TypstLiteral {
+        let (handle, path, title) = match node.vertebra.and_then(|i| self.vertebrae.get(i)) {
+            Some(v) => (
+                TypstLiteral::str(v.handle.as_str()),
+                TypstLiteral::str(v.rel_path.as_str()),
+                TypstLiteral::str(v.title.as_str()),
+            ),
+            None => (
+                TypstLiteral::None,
+                TypstLiteral::None,
+                TypstLiteral::str(node.title.as_deref().unwrap_or(node.segment.as_str())),
+            ),
+        };
+        let children =
+            TypstLiteral::Array(node.children.iter().map(|c| self.node_literal(c)).collect());
+        TypstLiteral::Dict(vec![
+            ("title".to_string(), title),
+            ("handle".to_string(), handle),
+            ("path".to_string(), path),
+            ("children".to_string(), children),
+        ])
+    }
+
+    /// The flat spine as a [`TypstLiteral`] array-of-dictionaries, in the same
+    /// pre-order as [`Self::flat_vertebrae`]: one entry per clickable vertebra
+    /// (group nodes excluded) with `handle`, `path`, and `title`.
+    fn spine_flat(&self) -> TypstLiteral {
         TypstLiteral::Array(
-            self.vertebrae
-                .iter()
+            self.flat_vertebrae()
+                .into_iter()
                 .map(|v| {
                     TypstLiteral::Dict(vec![
                         ("handle".to_string(), TypstLiteral::str(v.handle.as_str())),
@@ -1202,12 +1242,50 @@ mod tests {
         // Each carries its OWN handle...
         assert!(root_prelude.contains("handle: \"intro\""));
         assert!(nested_prelude.contains("handle: \"chapters:intro\""));
-        // ...and the full flat spine (both vertebrae, with path).
+        // ...and the full flat spine (both vertebrae, with path), both as the
+        // tree (`spine`) and the flat pre-order list (`spine-flat`).
         for p in [root_prelude, nested_prelude] {
             assert!(p.starts_with("#let rheo-context = "));
+            assert!(p.contains("spine-flat"));
             assert!(p.contains("path: \"content/intro.typ\""));
             assert!(p.contains("path: \"content/chapters/intro.typ\""));
         }
+    }
+
+    #[test]
+    fn spine_tree_nests_group_nodes_with_none_handle_and_path() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let content = root.join("content");
+        let chapters = content.join("chapters");
+        fs::create_dir_all(&chapters).unwrap();
+        fs::write(content.join("intro.typ"), "= Intro\n").unwrap();
+        fs::write(chapters.join("one.typ"), "= One\n").unwrap();
+
+        let scan = SpineScan::run(&content, &[]).unwrap();
+        let layout = SpineLayout::OnePerVertebra {
+            ext: "html".into(),
+            format: "html".into(),
+        };
+        let spine = VirtualSpine::build(scan, root, layout).unwrap();
+
+        let tree = spine.spine_tree().serialize();
+        // Root leaf carries its own handle/path/title.
+        assert!(tree.contains("handle: \"intro\""));
+        assert!(tree.contains("path: \"content/intro.typ\""));
+        // The `chapters` directory has no landing page: a group node with
+        // handle/path `none` and its own title, nesting `one` as a child.
+        assert!(tree.contains("handle: none"));
+        assert!(tree.contains("path: none"));
+        assert!(tree.contains("title: \"Chapters\""));
+        assert!(tree.contains("children:"));
+        assert!(tree.contains("handle: \"chapters:one\""));
+
+        // spine-flat only lists clickable vertebrae, in pre-order.
+        let flat = spine.spine_flat().serialize();
+        assert!(flat.contains("handle: \"intro\""));
+        assert!(flat.contains("handle: \"chapters:one\""));
+        assert!(!flat.contains("title: \"Chapters\""));
     }
 
     #[test]
@@ -1441,7 +1519,12 @@ mod tests {
         nodes
             .iter()
             .find(|n| n.segment == segment)
-            .unwrap_or_else(|| panic!("node '{segment}' not found among {:?}", nodes.iter().map(|n| &n.segment).collect::<Vec<_>>()))
+            .unwrap_or_else(|| {
+                panic!(
+                    "node '{segment}' not found among {:?}",
+                    nodes.iter().map(|n| &n.segment).collect::<Vec<_>>()
+                )
+            })
     }
 
     #[test]
@@ -1537,7 +1620,11 @@ mod tests {
         assert_eq!(guide.title.as_deref(), Some("Guide")); // derived from name
         let child_segs: Vec<&str> = guide.children.iter().map(|c| c.segment.as_str()).collect();
         assert_eq!(child_segs, vec!["a", "b"]);
-        assert!(out.tree.iter().any(|n| n.segment == "c" && n.vertebra.is_some()));
+        assert!(
+            out.tree
+                .iter()
+                .any(|n| n.segment == "c" && n.vertebra.is_some())
+        );
         // Children reindexed to valid file positions.
         for c in &guide.children {
             let idx = c.vertebra.expect("section child is a leaf vertebra");
@@ -1556,7 +1643,11 @@ mod tests {
         let guide = out.tree.iter().find(|n| n.segment == "guide").unwrap();
         // guide holds leaf a, then nested group advanced holding c.
         assert_eq!(guide.children[0].segment, "a");
-        let advanced = guide.children.iter().find(|n| n.segment == "advanced").unwrap();
+        let advanced = guide
+            .children
+            .iter()
+            .find(|n| n.segment == "advanced")
+            .unwrap();
         assert!(advanced.vertebra.is_none());
         assert_eq!(advanced.children[0].segment, "c");
         assert!(out.tree.iter().any(|n| n.segment == "b"));

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -1,3 +1,4 @@
+use crate::config::SpineSection;
 use crate::parser;
 use crate::parser::{DocumentDate, RheoValue};
 use crate::plugins::SpineOptions;
@@ -74,6 +75,7 @@ impl SpineOptions {
 /// A content directory scanned into a structured spine tree.
 ///
 /// Built via [`SpineScan::run`], which walks the directory on disk.
+#[derive(Debug)]
 pub struct SpineScan {
     /// Ordered flat file list in pre-order (feeds `VirtualSpine::build` later).
     pub files: Vec<PathBuf>,
@@ -311,6 +313,221 @@ impl SpineScan {
             .collect::<Vec<_>>()
             .join(" ")
     }
+
+    /// Apply `[[spine.section]]` virtual-directory layering (knob 2) to a scanned
+    /// spine, returning a new [`SpineScan`] with the tree + flat file list rebuilt.
+    ///
+    /// Each section is a virtual directory: its `include` globs pull matching
+    /// leaf files out of their scanned position and nest them under a group node
+    /// named `name` (arbitrary depth via nested `section`). A file placed under
+    /// section `guide` later resolves to handle `guide:<stem>`, exactly as if it
+    /// lived in `content/guide/`. Only leaf files are movable; a directory
+    /// landing page (`index.typ`) stays where it is. Returns `self` unchanged
+    /// when there are no sections.
+    pub fn apply_sections(self, content_dir: &Path, sections: &[SpineSection]) -> Result<SpineScan> {
+        if sections.is_empty() {
+            return Ok(self);
+        }
+        Self::validate_sections(sections)?;
+
+        let mut roots = Self::to_path_nodes(&self.tree, &self.files);
+
+        // All movable (leaf) file paths currently in the tree.
+        let mut leaves = Vec::new();
+        Self::collect_leaf_files(&roots, &mut leaves);
+
+        // Build virtual section nodes, claiming leaf files (each to the first
+        // section, pre-order, whose include matches it).
+        let mut claimed: HashSet<PathBuf> = HashSet::new();
+        let virtual_nodes =
+            Self::build_section_nodes(content_dir, sections, &leaves, &mut claimed)?;
+
+        // Remove claimed leaves from the scanned tree, pruning emptied groups.
+        Self::prune_claimed(&mut roots, &claimed);
+
+        // Insert virtual dirs at top level; order top-level siblings by segment,
+        // just as on-disk directories are ordered by name.
+        roots.extend(virtual_nodes);
+        roots.sort_by(|a, b| a.segment.cmp(&b.segment));
+
+        // Re-index into SpineNode + flat file list (pre-order, parent before child).
+        let mut files = Vec::new();
+        let tree = Self::reindex(&roots, &mut files);
+
+        if files.is_empty() {
+            return Err(RheoError::project_config(
+                "spine is empty after applying sections",
+            ));
+        }
+        Ok(SpineScan { files, tree })
+    }
+
+    /// Validate section names recursively: each `name` must be a non-empty slug
+    /// and sibling names must be unique (they behave like directory names).
+    fn validate_sections(sections: &[SpineSection]) -> Result<()> {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for s in sections {
+            if sanitize_handle_segment(&s.name).is_empty() {
+                return Err(RheoError::project_config(format!(
+                    "spine section name '{}' is not a valid slug",
+                    s.name
+                )));
+            }
+            if !seen.insert(s.name.as_str()) {
+                return Err(RheoError::project_config(format!(
+                    "duplicate spine section name '{}'",
+                    s.name
+                )));
+            }
+            Self::validate_sections(&s.section)?;
+        }
+        Ok(())
+    }
+
+    /// Convert an indexed [`SpineNode`] tree into a path-carrying working tree.
+    fn to_path_nodes(nodes: &[SpineNode], files: &[PathBuf]) -> Vec<PathNode> {
+        nodes
+            .iter()
+            .map(|n| PathNode {
+                segment: n.segment.clone(),
+                title: n.title.clone(),
+                file: n.vertebra.and_then(|i| files.get(i)).cloned(),
+                children: Self::to_path_nodes(&n.children, files),
+            })
+            .collect()
+    }
+
+    /// Collect every movable leaf file path (a node with a file and no children).
+    fn collect_leaf_files(nodes: &[PathNode], out: &mut Vec<PathBuf>) {
+        for n in nodes {
+            if n.children.is_empty()
+                && let Some(f) = &n.file
+            {
+                out.push(f.clone());
+            }
+            Self::collect_leaf_files(&n.children, out);
+        }
+    }
+
+    /// Build virtual-directory nodes from `sections`, claiming leaf files.
+    fn build_section_nodes(
+        content_dir: &Path,
+        sections: &[SpineSection],
+        leaves: &[PathBuf],
+        claimed: &mut HashSet<PathBuf>,
+    ) -> Result<Vec<PathNode>> {
+        let mut result = Vec::new();
+        for s in sections {
+            let mut children = Vec::new();
+
+            // Match this section's includes, in listed order; within one glob,
+            // lexicographic. A file is claimed by the first section that matches.
+            let mut matched: Vec<PathBuf> = Vec::new();
+            for g in &s.include {
+                let matcher = GlobBuilder::new(g)
+                    .literal_separator(true)
+                    .build()
+                    .map_err(|e| {
+                        RheoError::project_config(format!(
+                            "invalid include glob '{}' in spine section '{}': {}",
+                            g, s.name, e
+                        ))
+                    })?
+                    .compile_matcher();
+                let mut ms: Vec<PathBuf> = leaves
+                    .iter()
+                    .filter(|p| !claimed.contains(*p))
+                    .filter(|p| {
+                        let rel = p.strip_prefix(content_dir).unwrap_or(p);
+                        matcher.is_match(to_forward_slash(rel))
+                    })
+                    .cloned()
+                    .collect();
+                ms.sort();
+                for m in ms {
+                    if claimed.insert(m.clone()) {
+                        matched.push(m);
+                    }
+                }
+            }
+            if !s.include.is_empty() && matched.is_empty() {
+                return Err(RheoError::project_config(format!(
+                    "spine section '{}' include matched no files",
+                    s.name
+                )));
+            }
+
+            for p in matched {
+                let stem = p
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                children.push(PathNode {
+                    segment: sanitize_handle_segment(stem),
+                    title: None,
+                    file: Some(p),
+                    children: Vec::new(),
+                });
+            }
+
+            // Nested virtual directories.
+            let nested = Self::build_section_nodes(content_dir, &s.section, leaves, claimed)?;
+            children.extend(nested);
+
+            result.push(PathNode {
+                segment: sanitize_handle_segment(&s.name),
+                title: Some(s.title.clone().unwrap_or_else(|| Self::prettify(&s.name))),
+                file: None,
+                children,
+            });
+        }
+        Ok(result)
+    }
+
+    /// Remove claimed leaf files from the working tree, dropping any group node
+    /// left with neither a file nor children.
+    fn prune_claimed(nodes: &mut Vec<PathNode>, claimed: &HashSet<PathBuf>) {
+        nodes.retain_mut(|n| {
+            Self::prune_claimed(&mut n.children, claimed);
+            if n.children.is_empty()
+                && let Some(f) = &n.file
+                && claimed.contains(f)
+            {
+                return false;
+            }
+            !(n.file.is_none() && n.children.is_empty())
+        });
+    }
+
+    /// Re-index a working tree into an indexed [`SpineNode`] tree, rebuilding the
+    /// flat file list in pre-order (parent before children).
+    fn reindex(nodes: &[PathNode], files: &mut Vec<PathBuf>) -> Vec<SpineNode> {
+        nodes
+            .iter()
+            .map(|n| {
+                let vertebra = n.file.as_ref().map(|f| {
+                    let idx = files.len();
+                    files.push(f.clone());
+                    idx
+                });
+                SpineNode {
+                    segment: n.segment.clone(),
+                    title: n.title.clone(),
+                    vertebra,
+                    children: Self::reindex(&n.children, files),
+                }
+            })
+            .collect()
+    }
+}
+
+/// A working spine node carrying file PATHS (not indices), used while
+/// transforming the scanned tree before re-indexing into [`SpineNode`].
+struct PathNode {
+    segment: String,
+    title: Option<String>,
+    file: Option<PathBuf>,
+    children: Vec<PathNode>,
 }
 
 // ── Bundle spine: VirtualSpine, Vertebra, SpineLayout ────────────────────────
@@ -355,6 +572,7 @@ impl Vertebra {
 
 /// One node in the structured spine. Mirrors directory / section nesting to
 /// arbitrary depth as a structural overlay over the flat `vertebrae`.
+#[derive(Debug)]
 pub struct SpineNode {
     /// Handle segment contributed by this node (dir name, file stem, or section
     /// name). For the trivial flat tree this is the vertebra's full handle.
@@ -1267,5 +1485,99 @@ mod tests {
             Err(e) => assert!(e.to_string().contains("need at least one .typ file")),
             Ok(_) => panic!("expected empty-scan error"),
         }
+    }
+
+    // ── apply_sections tests ─────────────────────────────────────────────────
+
+    fn section(name: &str, include: &[&str]) -> SpineSection {
+        SpineSection {
+            name: name.into(),
+            title: None,
+            include: include.iter().map(|s| s.to_string()).collect(),
+            section: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn apply_sections_groups_flat_files() {
+        let temp = create_test_dir_with_files(&["a.typ", "b.typ", "c.typ"]);
+        let scan = SpineScan::run(temp.path(), &[]).unwrap();
+        let out = scan
+            .apply_sections(temp.path(), &[section("guide", &["a.typ", "b.typ"])])
+            .unwrap();
+
+        // c stays top-level; guide is a group node holding a and b.
+        assert_eq!(out.files.len(), 3);
+        let guide = out.tree.iter().find(|n| n.segment == "guide").unwrap();
+        assert!(guide.vertebra.is_none()); // non-clickable group
+        assert_eq!(guide.title.as_deref(), Some("Guide")); // derived from name
+        let child_segs: Vec<&str> = guide.children.iter().map(|c| c.segment.as_str()).collect();
+        assert_eq!(child_segs, vec!["a", "b"]);
+        assert!(out.tree.iter().any(|n| n.segment == "c" && n.vertebra.is_some()));
+        // Children reindexed to valid file positions.
+        for c in &guide.children {
+            let idx = c.vertebra.expect("section child is a leaf vertebra");
+            assert!(idx < out.files.len());
+        }
+    }
+
+    #[test]
+    fn apply_sections_nests_subsections() {
+        let temp = create_test_dir_with_files(&["a.typ", "b.typ", "c.typ"]);
+        let scan = SpineScan::run(temp.path(), &[]).unwrap();
+        let mut guide = section("guide", &["a.typ"]);
+        guide.section = vec![section("advanced", &["c.typ"])];
+        let out = scan.apply_sections(temp.path(), &[guide]).unwrap();
+
+        let guide = out.tree.iter().find(|n| n.segment == "guide").unwrap();
+        // guide holds leaf a, then nested group advanced holding c.
+        assert_eq!(guide.children[0].segment, "a");
+        let advanced = guide.children.iter().find(|n| n.segment == "advanced").unwrap();
+        assert!(advanced.vertebra.is_none());
+        assert_eq!(advanced.children[0].segment, "c");
+        assert!(out.tree.iter().any(|n| n.segment == "b"));
+    }
+
+    #[test]
+    fn apply_sections_title_derived_strips_numeric_prefix() {
+        let temp = create_test_dir_with_files(&["a.typ"]);
+        let scan = SpineScan::run(temp.path(), &[]).unwrap();
+        let out = scan
+            .apply_sections(temp.path(), &[section("01-guide", &["a.typ"])])
+            .unwrap();
+        let guide = out.tree.iter().find(|n| n.segment == "01-guide").unwrap();
+        assert_eq!(guide.title.as_deref(), Some("Guide")); // prefix stripped for title, kept in segment
+    }
+
+    #[test]
+    fn apply_sections_include_no_match_errors() {
+        let temp = create_test_dir_with_files(&["a.typ"]);
+        let scan = SpineScan::run(temp.path(), &[]).unwrap();
+        let err = scan
+            .apply_sections(temp.path(), &[section("guide", &["nope.typ"])])
+            .unwrap_err();
+        assert!(err.to_string().contains("matched no files"));
+    }
+
+    #[test]
+    fn apply_sections_duplicate_sibling_name_errors() {
+        let temp = create_test_dir_with_files(&["a.typ", "b.typ"]);
+        let scan = SpineScan::run(temp.path(), &[]).unwrap();
+        let err = scan
+            .apply_sections(
+                temp.path(),
+                &[section("guide", &["a.typ"]), section("guide", &["b.typ"])],
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate spine section"));
+    }
+
+    #[test]
+    fn apply_sections_empty_is_noop() {
+        let temp = create_test_dir_with_files(&["a.typ", "b.typ"]);
+        let scan = SpineScan::run(temp.path(), &[]).unwrap();
+        let before = scan.files.len();
+        let out = scan.apply_sections(temp.path(), &[]).unwrap();
+        assert_eq!(out.files.len(), before);
     }
 }

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -136,6 +136,38 @@ impl SpineScan {
             .map_err(|e| RheoError::project_config(format!("invalid exclude globs: {}", e)))
     }
 
+    /// Build a flat spine (no nesting) from an explicit, ordered file list.
+    ///
+    /// Each file becomes a top-level leaf whose segment is its full `:`-joined
+    /// disk-path handle relative to `content_dir` (e.g. `a/notes.typ` →
+    /// `a:notes`), preserving the given order. Used for single-file projects and
+    /// wherever an explicit ordering is supplied rather than a directory scan.
+    pub fn flat(files: &[PathBuf], content_dir: &Path) -> SpineScan {
+        let tree = files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                let stem =
+                    to_forward_slash(&f.strip_prefix(content_dir).unwrap_or(f).with_extension(""));
+                let segment = stem
+                    .split('/')
+                    .map(sanitize_handle_segment)
+                    .collect::<Vec<_>>()
+                    .join(":");
+                SpineNode {
+                    segment,
+                    title: None,
+                    vertebra: Some(i),
+                    children: Vec::new(),
+                }
+            })
+            .collect();
+        SpineScan {
+            files: files.to_vec(),
+            tree,
+        }
+    }
+
     /// Return `true` if `path` (relative to `content_dir`) matches any exclude glob.
     fn is_excluded(content_dir: &Path, path: &Path, exclude: &GlobSet) -> bool {
         let rel = path.strip_prefix(content_dir).unwrap_or(path);
@@ -634,23 +666,40 @@ impl VirtualSpine {
         node.vertebra.and_then(|i| self.vertebrae.get(i))
     }
 
+    /// Fill `handles[i]` with the `:`-joined segment path from the tree root to
+    /// the node whose `vertebra` is `Some(i)`, walking pre-order. Group nodes
+    /// contribute their segment as a prefix to descendants without claiming a slot.
+    fn assign_handles(nodes: &[SpineNode], prefix: &str, handles: &mut [String]) {
+        for n in nodes {
+            let seg = if prefix.is_empty() {
+                n.segment.clone()
+            } else {
+                format!("{prefix}:{}", n.segment)
+            };
+            if let Some(i) = n.vertebra
+                && let Some(slot) = handles.get_mut(i)
+            {
+                *slot = seg.clone();
+            }
+            Self::assign_handles(&n.children, &seg, handles);
+        }
+    }
+
     /// Resolve a list of spine files into a `VirtualSpine` with computed handles,
     /// output paths, and titles.
     ///
     /// `content_dir` is the project content root; stems are computed relative to it
     /// so `content/chapters/intro.typ` yields handle `intro` (or `chapters:intro`
     /// on a cross-directory stem collision). Pass `project_root` for `#include` paths.
-    pub fn build(
-        files: &[PathBuf],
-        content_dir: &Path,
-        project_root: &Path,
-        layout: SpineLayout,
-    ) -> Result<Self> {
-        // Stem relative to content_dir (no extension, forward-slash).
-        let rel_stems: Vec<String> = files
-            .iter()
-            .map(|f| to_forward_slash(&f.strip_prefix(content_dir).unwrap_or(f).with_extension("")))
-            .collect();
+    pub fn build(scan: SpineScan, project_root: &Path, layout: SpineLayout) -> Result<Self> {
+        let SpineScan { files, tree } = scan;
+
+        // Handle per file, derived from its position in the spine tree: the
+        // ':'-joined path of ancestor segments down to the file. For a plain
+        // directory scan this equals the disk path; a file pulled under a
+        // `[[spine.section]]` gains that section's segment as a prefix.
+        let mut handles: Vec<String> = vec![String::new(); files.len()];
+        Self::assign_handles(&tree, "", &mut handles);
 
         // First pass: parse each file, compute handles, collect user labels.
         struct FileInfo {
@@ -673,22 +722,9 @@ impl VirtualSpine {
 
         let file_infos: Result<Vec<FileInfo>> = files
             .iter()
-            .zip(rel_stems.iter())
-            .map(|(file, rel_stem)| {
-                let segments: Vec<&str> = rel_stem.split('/').collect();
-
-                // Canonical handle: bare stem for root-level files, path-prefixed
-                // with ':' separator for nested files ("a/notes" → "a:notes").
-                let handle = if segments.len() > 1 {
-                    segments
-                        .iter()
-                        .map(|s| sanitize_handle_segment(s))
-                        .collect::<Vec<_>>()
-                        .join(":")
-                } else {
-                    sanitize_handle_segment(segments[0])
-                };
-
+            .zip(handles.iter())
+            .map(|(file, handle)| {
+                let handle = handle.clone();
                 let escape = format!("{handle}.typ");
 
                 let output_path = match &layout {
@@ -781,18 +817,6 @@ impl VirtualSpine {
             .collect();
 
         let vertebrae = vertebrae?;
-
-        // Trivial flat tree: one top-level node per vertebra, in order.
-        let tree: Vec<SpineNode> = vertebrae
-            .iter()
-            .enumerate()
-            .map(|(i, v)| SpineNode {
-                segment: v.handle.clone(),
-                title: None,
-                vertebra: Some(i),
-                children: Vec::new(),
-            })
-            .collect();
 
         debug_assert!(
             {
@@ -1098,7 +1122,7 @@ mod tests {
             ext: "html".into(),
             format: "html".into(),
         };
-        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+        let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
         assert_eq!(spine.vertebrae[0].handle, "intro");
         assert_eq!(spine.vertebrae[0].extra_handles, vec!["intro.typ"]);
@@ -1121,7 +1145,7 @@ mod tests {
             ext: "html".into(),
             format: "html".into(),
         };
-        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+        let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
         let expected: Vec<&str> = spine.vertebrae.iter().map(|v| v.handle.as_str()).collect();
         let actual: Vec<&str> = spine
@@ -1145,7 +1169,7 @@ mod tests {
             ext: "html".into(),
             format: "html".into(),
         };
-        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+        let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
         let v = &spine.vertebrae[0];
 
         // The raw source is retained for the Mould stage.
@@ -1167,7 +1191,7 @@ mod tests {
             ext: "html".into(),
             format: "html".into(),
         };
-        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+        let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
         let preludes = spine.rheo_context_preludes(Some("html"));
         // One prelude per vertebra, keyed by include path.
@@ -1199,7 +1223,7 @@ mod tests {
             ext: "html".into(),
             format: "html".into(),
         };
-        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+        let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
         // Some(target) -> `target` field in both prelude and global context.
         let with = spine.rheo_context_preludes(Some("html"));
@@ -1234,7 +1258,7 @@ mod tests {
             ext: "html".into(),
             format: "html".into(),
         };
-        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+        let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
         assert_eq!(spine.vertebrae[0].handle, "a:notes");
         assert_eq!(spine.vertebrae[1].handle, "b:notes");
@@ -1374,7 +1398,7 @@ mod tests {
             format: "html".into(),
         };
         // Without prefixing, the raw `<intro>` collides with the canonical handle.
-        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+        let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
         assert_eq!(spine.vertebrae[0].handle, "intro");
         // Canonical was user-claimed → not emitted.
@@ -1401,7 +1425,7 @@ mod tests {
             ext: "html".into(),
             format: "html".into(),
         };
-        let result = VirtualSpine::build(&files, &content, root, layout);
+        let result = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout);
         match result {
             Err(e) => {
                 let msg = e.to_string();

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -6,6 +6,7 @@ use crate::util::path::{sanitize_handle_segment, to_forward_slash};
 use crate::util::pdf::DocumentTitle;
 use crate::util::typst_literal::TypstLiteral;
 use crate::{Result, RheoError, TYP_EXT};
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -65,6 +66,250 @@ impl SpineOptions {
                     .unwrap_or(false)
             })
             .collect()
+    }
+}
+
+// ── Directory scan: SpineScan ────────────────────────────────────────────────
+
+/// A content directory scanned into a structured spine tree.
+///
+/// Built via [`SpineScan::run`], which walks the directory on disk.
+pub struct SpineScan {
+    /// Ordered flat file list in pre-order (feeds `VirtualSpine::build` later).
+    pub files: Vec<PathBuf>,
+    /// Structured tree; `node.vertebra` indexes into `files` (== pre-order position).
+    pub tree: Vec<SpineNode>,
+}
+
+impl SpineScan {
+    /// Recursively scan `content_dir`, producing the structured spine tree and
+    /// its matching ordered flat file list.
+    ///
+    /// `exclude` is a list of glob patterns matched against each candidate
+    /// path relative to `content_dir` (forward-slash separated); matching
+    /// files or directories are dropped entirely.
+    pub fn run(content_dir: &Path, exclude: &[String]) -> Result<SpineScan> {
+        let exclude_set = Self::build_exclude_set(exclude)?;
+
+        let mut files = Vec::new();
+        let tree = Self::scan_dir(content_dir, content_dir, &exclude_set, &mut files)?;
+
+        if files.is_empty() {
+            return Err(RheoError::project_config("need at least one .typ file"));
+        }
+
+        debug_assert!(
+            {
+                let mut indices = Vec::new();
+                for node in &tree {
+                    node.collect_indices(&mut indices);
+                }
+                let unique: HashSet<usize> = indices.iter().copied().collect();
+                indices.len() == unique.len()
+                    && indices.iter().all(|&i| i < files.len())
+            },
+            "spine scan tree indices must be unique and in range"
+        );
+
+        Ok(SpineScan { files, tree })
+    }
+
+    /// Compile exclude globs into a path-aware [`GlobSet`] (matched against
+    /// content_dir-relative, forward-slashed paths). `literal_separator` keeps
+    /// `*` from crossing `/` while `**` still descends, matching the documented
+    /// exclude semantics.
+    fn build_exclude_set(exclude: &[String]) -> Result<GlobSet> {
+        let mut builder = GlobSetBuilder::new();
+        for g in exclude {
+            let glob = GlobBuilder::new(g)
+                .literal_separator(true)
+                .build()
+                .map_err(|e| {
+                    RheoError::project_config(format!("invalid exclude glob '{}': {}", g, e))
+                })?;
+            builder.add(glob);
+        }
+        builder
+            .build()
+            .map_err(|e| RheoError::project_config(format!("invalid exclude globs: {}", e)))
+    }
+
+    /// Return `true` if `path` (relative to `content_dir`) matches any exclude glob.
+    fn is_excluded(content_dir: &Path, path: &Path, exclude: &GlobSet) -> bool {
+        let rel = path.strip_prefix(content_dir).unwrap_or(path);
+        exclude.is_match(to_forward_slash(rel))
+    }
+
+    /// Scan one directory, recursing into subdirectories. Returns the child
+    /// node list for `dir`; pushes discovered files into `files` in pre-order.
+    fn scan_dir(
+        content_dir: &Path,
+        dir: &Path,
+        exclude: &GlobSet,
+        files: &mut Vec<PathBuf>,
+    ) -> Result<Vec<SpineNode>> {
+        let mut entries: Vec<fs::DirEntry> = fs::read_dir(dir)
+            .map_err(|e| RheoError::project_config(format!("failed to read dir '{}': {}", dir.display(), e)))?
+            .filter_map(|e| e.ok())
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        let mut nodes = Vec::new();
+
+        for entry in entries {
+            let path = entry.path();
+
+            if Self::is_excluded(content_dir, &path, exclude) {
+                continue;
+            }
+
+            if path.is_dir() {
+                if let Some(node) = Self::scan_subdir(content_dir, &path, exclude, files)? {
+                    nodes.push(node);
+                }
+            } else if path.extension().and_then(|e| e.to_str()) == Some(&TYP_EXT[1..]) {
+                // Root-level index.typ is a normal leaf; only nested dirs treat
+                // it as a landing page (handled in scan_subdir).
+                let stem = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                let idx = files.len();
+                files.push(path.clone());
+                nodes.push(SpineNode {
+                    segment: sanitize_handle_segment(stem),
+                    title: None,
+                    vertebra: Some(idx),
+                    children: Vec::new(),
+                });
+            }
+        }
+
+        Ok(nodes)
+    }
+
+    /// Scan a subdirectory, deciding whether it has a landing page (clickable
+    /// node) or not (group node). Returns `None` if the subtree contains no
+    /// `.typ` files after exclusion (pruned).
+    fn scan_subdir(
+        content_dir: &Path,
+        dir: &Path,
+        exclude: &GlobSet,
+        files: &mut Vec<PathBuf>,
+    ) -> Result<Option<SpineNode>> {
+        let dirname = dir
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+
+        let mut entries: Vec<fs::DirEntry> = fs::read_dir(dir)
+            .map_err(|e| RheoError::project_config(format!("failed to read dir '{}': {}", dir.display(), e)))?
+            .filter_map(|e| e.ok())
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        // Find the landing file: prefer index.typ, else <dirname>.typ.
+        let index_name = format!("index{}", TYP_EXT);
+        let named_name = format!("{}{}", dirname, TYP_EXT);
+
+        let landing_path = entries
+            .iter()
+            .map(|e| e.path())
+            .filter(|p| !Self::is_excluded(content_dir, p, exclude))
+            .find(|p| p.file_name().and_then(|n| n.to_str()) == Some(index_name.as_str()))
+            .or_else(|| {
+                entries
+                    .iter()
+                    .map(|e| e.path())
+                    .filter(|p| !Self::is_excluded(content_dir, p, exclude))
+                    .find(|p| p.file_name().and_then(|n| n.to_str()) == Some(named_name.as_str()))
+            });
+
+        let (vertebra, title) = if let Some(landing) = &landing_path {
+            let idx = files.len();
+            files.push(landing.clone());
+            (Some(idx), None)
+        } else {
+            (None, Some(Self::prettify(&dirname)))
+        };
+
+        // Recurse for children, skipping the landing file itself.
+        let mut children = Vec::new();
+        for entry in &entries {
+            let path = entry.path();
+
+            if Some(&path) == landing_path.as_ref() {
+                continue;
+            }
+            if Self::is_excluded(content_dir, &path, exclude) {
+                continue;
+            }
+
+            if path.is_dir() {
+                if let Some(node) = Self::scan_subdir(content_dir, &path, exclude, files)? {
+                    children.push(node);
+                }
+            } else if path.extension().and_then(|e| e.to_str()) == Some(&TYP_EXT[1..]) {
+                let stem = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                let idx = files.len();
+                files.push(path.clone());
+                children.push(SpineNode {
+                    segment: sanitize_handle_segment(stem),
+                    title: None,
+                    vertebra: Some(idx),
+                    children: Vec::new(),
+                });
+            }
+        }
+
+        if vertebra.is_none() && children.is_empty() {
+            // Empty subtree after exclusion/pruning: drop the whole node.
+            return Ok(None);
+        }
+
+        Ok(Some(SpineNode {
+            segment: sanitize_handle_segment(&dirname),
+            title,
+            vertebra,
+            children,
+        }))
+    }
+
+    /// Derive a group title from a directory name: strip a leading numeric
+    /// order prefix (e.g. `01-`, `1_`), replace `-`/`_` with spaces, and Title
+    /// Case each word.
+    fn prettify(dirname: &str) -> String {
+        let digits_end = dirname
+            .find(|c: char| !c.is_ascii_digit())
+            .unwrap_or(0);
+        let stripped = if digits_end > 0
+            && dirname[digits_end..]
+                .starts_with(['-', '_'])
+        {
+            &dirname[digits_end + 1..]
+        } else {
+            dirname
+        };
+
+        stripped
+            .split(['-', '_'])
+            .filter(|w| !w.is_empty())
+            .map(|w| {
+                let mut chars = w.chars();
+                match chars.next() {
+                    Some(first) => {
+                        first.to_uppercase().collect::<String>()
+                            + &chars.as_str().to_lowercase()
+                    }
+                    None => String::new(),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 }
 
@@ -945,6 +1190,82 @@ mod tests {
                 assert!(msg.contains("intro.typ"), "error should name label: {msg}");
             }
             Ok(_) => panic!("expected escape collision error"),
+        }
+    }
+
+    // ── SpineScan tests ─────────────────────────────────────────────────────
+
+    fn find_node<'a>(nodes: &'a [SpineNode], segment: &str) -> &'a SpineNode {
+        nodes
+            .iter()
+            .find(|n| n.segment == segment)
+            .unwrap_or_else(|| panic!("node '{segment}' not found among {:?}", nodes.iter().map(|n| &n.segment).collect::<Vec<_>>()))
+    }
+
+    #[test]
+    fn scan_nested_tree_with_landing_pages() {
+        let temp = create_test_dir_with_files(&[
+            "index.typ",
+            "intro.typ",
+            "guide/index.typ",
+            "guide/a.typ",
+            "guide/b.typ",
+            "guide/deep/x.typ",
+        ]);
+
+        let result = SpineScan::run(temp.path(), &[]).unwrap();
+        assert_eq!(result.files.len(), 6);
+
+        let guide = find_node(&result.tree, "guide");
+        assert!(guide.vertebra.is_some());
+        assert_eq!(guide.segment, "guide");
+
+        let a = find_node(&guide.children, "a");
+        assert!(a.vertebra.is_some());
+        let _b = find_node(&guide.children, "b");
+
+        let deep = find_node(&guide.children, "deep");
+        assert!(deep.vertebra.is_none());
+        let x = find_node(&deep.children, "x");
+        assert!(x.vertebra.is_some());
+    }
+
+    #[test]
+    fn scan_dir_without_index_is_group_node() {
+        let temp = create_test_dir_with_files(&["extras/note.typ"]);
+        let result = SpineScan::run(temp.path(), &[]).unwrap();
+
+        let extras = find_node(&result.tree, "extras");
+        assert!(extras.vertebra.is_none());
+        assert_eq!(extras.title, Some("Extras".to_string()));
+    }
+
+    #[test]
+    fn scan_numeric_prefix_dir_title() {
+        let temp = create_test_dir_with_files(&["01-basics/setup.typ"]);
+        let result = SpineScan::run(temp.path(), &[]).unwrap();
+
+        let basics = find_node(&result.tree, "01-basics");
+        assert_eq!(basics.title, Some("Basics".to_string()));
+    }
+
+    #[test]
+    fn scan_exclude_prunes_subtree() {
+        let temp = create_test_dir_with_files(&["drafts/wip.typ", "keep.typ"]);
+        let result = SpineScan::run(temp.path(), &["drafts/**".to_string()]).unwrap();
+
+        assert!(result.tree.iter().all(|n| n.segment != "drafts"));
+        assert!(result.tree.iter().any(|n| n.segment == "keep"));
+        assert_eq!(result.files.len(), 1);
+    }
+
+    #[test]
+    fn scan_empty_after_exclude_errors() {
+        let temp = create_test_dir_with_files(&["only.typ"]);
+        let result = SpineScan::run(temp.path(), &["only.typ".to_string()]);
+        match result {
+            Err(e) => assert!(e.to_string().contains("need at least one .typ file")),
+            Ok(_) => panic!("expected empty-scan error"),
         }
     }
 }

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -582,9 +582,21 @@ pub struct VirtualSpine {
     /// Structural overlay over `vertebrae`; a flat one-level tree today, but the
     /// foundation for arbitrary nesting later.
     pub tree: Vec<SpineNode>,
+    /// Resolved title for the combined output document, when configured
+    /// (per-format `[plugin.spine] title`, else the global `[spine] title`).
+    /// Not set by `build()` itself — callers resolve it from config and apply
+    /// it with [`Self::with_title`], since `VirtualSpine` is built from a pure
+    /// directory scan with no config access of its own.
+    pub title: Option<String>,
 }
 
 impl VirtualSpine {
+    /// Attach a resolved spine title, builder-style.
+    pub fn with_title(mut self, title: Option<String>) -> Self {
+        self.title = title;
+        self
+    }
+
     /// Pre-order walk of `self.tree`, yielding `&Vertebra` for every node that
     /// points at one, in the same order as `self.vertebrae` for the trivial flat
     /// tree built by `build()`. Group nodes with `vertebra: None` still recurse
@@ -774,6 +786,7 @@ impl VirtualSpine {
             vertebrae,
             layout,
             tree,
+            title: None,
         })
     }
 
@@ -1222,6 +1235,7 @@ mod tests {
                 format: "html".into(),
             },
             tree: Vec::new(),
+            title: None,
         };
         let src = spine.source();
         assert!(src.contains("#document(\"intro.html\", format: \"html\""));
@@ -1264,6 +1278,7 @@ mod tests {
                 format: "pdf".into(),
             },
             tree: Vec::new(),
+            title: None,
         };
         let src = spine.source();
         assert!(src.contains("#document(\"doc.pdf\", format: \"pdf\""));
@@ -1308,6 +1323,7 @@ mod tests {
                 format: "pdf".into(),
             },
             tree: Vec::new(),
+            title: None,
         };
         assert!(spine.check_output_collisions().is_ok());
     }

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -1,7 +1,6 @@
 use crate::config::SpineSection;
 use crate::parser;
 use crate::parser::{DocumentDate, RheoValue};
-use crate::plugins::SpineOptions;
 use crate::reticulate::bundle_source::BundleSource;
 use crate::util::path::{sanitize_handle_segment, to_forward_slash};
 use crate::util::pdf::DocumentTitle;
@@ -12,63 +11,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use typst::syntax::Source;
-use walkdir::WalkDir;
-
-/// Generates a spine (ordered list of .typ files) based on configuration.
-impl SpineOptions {
-    /// Resolve vertebrae patterns into an ordered list of .typ files.
-    ///
-    /// If no vertebrae are configured, discovers all .typ files under `root`.
-    pub fn generate(&self, root: &Path) -> Result<Vec<PathBuf>> {
-        if self.vertebrae.is_empty() {
-            let mut typst_files = Self::collect_typst_files(root);
-            if typst_files.is_empty() {
-                return Err(RheoError::project_config("need at least one .typ file"));
-            }
-            typst_files.sort();
-            return Ok(typst_files);
-        }
-
-        let mut typst_files = Vec::new();
-        for pattern in &self.vertebrae {
-            let glob_pattern = root.join(pattern).display().to_string();
-            let glob = glob::glob(&glob_pattern).map_err(|e| {
-                RheoError::project_config(format!("invalid glob pattern '{}': {}", pattern, e))
-            })?;
-
-            let mut glob_files: Vec<PathBuf> = glob
-                .filter_map(|entry| entry.ok())
-                .filter(|path| path.is_file())
-                .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("typ"))
-                .collect();
-
-            // Sort by full path (lexicographic) for consistent ordering
-            glob_files.sort();
-            typst_files.extend(glob_files);
-        }
-
-        if typst_files.is_empty() {
-            return Err(RheoError::project_config("spine matched no .typ files"));
-        }
-
-        Ok(typst_files)
-    }
-
-    /// Discover every `.typ` file under `root` (unordered).
-    fn collect_typst_files(root: &Path) -> Vec<PathBuf> {
-        WalkDir::new(root)
-            .into_iter()
-            .filter_map(|entry| Some(entry.ok()?.path().to_path_buf()))
-            .filter(|entry| {
-                entry
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .map(|ext| ext == &TYP_EXT[1..])
-                    .unwrap_or(false)
-            })
-            .collect()
-    }
-}
 
 // ── Directory scan: SpineScan ────────────────────────────────────────────────
 
@@ -1053,97 +995,6 @@ mod tests {
             fs::write(&path, "").unwrap();
         }
         temp
-    }
-
-    fn spine_with_vertebrae(vertebrae: Vec<String>) -> SpineOptions {
-        SpineOptions {
-            title: Some("Test".to_string()),
-            vertebrae,
-        }
-    }
-
-    #[test]
-    fn test_generate_with_vertebrae() {
-        let temp = create_test_dir_with_files(&["a.typ", "b.typ", "c.typ"]);
-        let spine = spine_with_vertebrae(vec!["*.typ".to_string()]);
-        let result = spine.generate(temp.path());
-        assert!(result.is_ok());
-        let files = result.unwrap();
-        assert_eq!(files.len(), 3);
-    }
-
-    #[test]
-    fn test_generate_ordered_patterns() {
-        let temp = create_test_dir_with_files(&[
-            "cover.typ",
-            "chapters/ch1.typ",
-            "chapters/ch2.typ",
-            "appendix.typ",
-        ]);
-        let spine = SpineOptions {
-            title: Some("Book".to_string()),
-            vertebrae: vec![
-                "cover.typ".to_string(),
-                "chapters/*.typ".to_string(),
-                "appendix.typ".to_string(),
-            ],
-        };
-        let result = spine.generate(temp.path());
-        assert!(result.is_ok());
-        let files = result.unwrap();
-        assert_eq!(files.len(), 4);
-        assert_eq!(files[0].file_name().unwrap(), "cover.typ");
-        assert!(
-            files[1]
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .starts_with("ch")
-        );
-        assert!(
-            files[2]
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .starts_with("ch")
-        );
-        assert_eq!(files[3].file_name().unwrap(), "appendix.typ");
-    }
-
-    #[test]
-    fn test_generate_no_matches_error() {
-        let temp = create_test_dir_with_files(&["readme.md"]);
-        let spine = spine_with_vertebrae(vec!["*.typ".to_string()]);
-        let result = spine.generate(temp.path());
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("spine matched no .typ files")
-        );
-    }
-
-    #[test]
-    fn test_generate_empty_pattern_single_file() {
-        let temp = create_test_dir_with_files(&["single.typ"]);
-        let spine = spine_with_vertebrae(vec![]);
-        let result = spine.generate(temp.path());
-        assert!(result.is_ok());
-        let files = result.unwrap();
-        assert_eq!(files.len(), 1);
-    }
-
-    #[test]
-    fn test_generate_empty_pattern_multiple_files_returns_all() {
-        let temp = create_test_dir_with_files(&["a.typ", "b.typ"]);
-        let spine = spine_with_vertebrae(vec![]);
-        let result = spine.generate(temp.path());
-        assert!(result.is_ok());
-        let files = result.unwrap();
-        assert_eq!(files.len(), 2);
     }
 
     // ── VirtualSpine tests ──────────────────────────────────────────────────

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -108,6 +108,35 @@ impl Vertebra {
     }
 }
 
+/// One node in the structured spine. Mirrors directory / section nesting to
+/// arbitrary depth as a structural overlay over the flat `vertebrae`.
+pub struct SpineNode {
+    /// Handle segment contributed by this node (dir name, file stem, or section
+    /// name). For the trivial flat tree this is the vertebra's full handle.
+    pub segment: String,
+    /// Explicit group title. `None` for a leaf — display title comes from the
+    /// vertebra it points at.
+    pub title: Option<String>,
+    /// Index into `VirtualSpine.vertebrae` for this node's landing page, or
+    /// `None` for a non-clickable group node.
+    pub vertebra: Option<usize>,
+    /// Child nodes, in order.
+    pub children: Vec<SpineNode>,
+}
+
+impl SpineNode {
+    /// Pre-order walk: push this node's vertebra index (if any) then recurse
+    /// into children regardless of whether this node itself yielded one.
+    fn collect_indices(&self, out: &mut Vec<usize>) {
+        if let Some(i) = self.vertebra {
+            out.push(i);
+        }
+        for child in &self.children {
+            child.collect_indices(out);
+        }
+    }
+}
+
 /// A resolved spine ready for bundle compilation.
 ///
 /// Constructed via `VirtualSpine::build`; call `source()` to get the synthesized
@@ -115,9 +144,33 @@ impl Vertebra {
 pub struct VirtualSpine {
     pub vertebrae: Vec<Vertebra>,
     pub layout: SpineLayout,
+    /// Structural overlay over `vertebrae`; a flat one-level tree today, but the
+    /// foundation for arbitrary nesting later.
+    pub tree: Vec<SpineNode>,
 }
 
 impl VirtualSpine {
+    /// Pre-order walk of `self.tree`, yielding `&Vertebra` for every node that
+    /// points at one, in the same order as `self.vertebrae` for the trivial flat
+    /// tree built by `build()`. Group nodes with `vertebra: None` still recurse
+    /// into their children. A stale index is silently skipped, never panics.
+    pub fn flat_vertebrae(&self) -> Vec<&Vertebra> {
+        let mut indices = Vec::new();
+        for node in &self.tree {
+            node.collect_indices(&mut indices);
+        }
+        indices
+            .into_iter()
+            .filter_map(|i| self.vertebrae.get(i))
+            .collect()
+    }
+
+    /// The vertebra a tree node points at, or `None` for a group node or a
+    /// stale index. Never panics — looks up via `.get`.
+    pub fn vertebra_of(&self, node: &SpineNode) -> Option<&Vertebra> {
+        node.vertebra.and_then(|i| self.vertebrae.get(i))
+    }
+
     /// Resolve a list of spine files into a `VirtualSpine` with computed handles,
     /// output paths, and titles.
     ///
@@ -264,9 +317,36 @@ impl VirtualSpine {
             })
             .collect();
 
+        let vertebrae = vertebrae?;
+
+        // Trivial flat tree: one top-level node per vertebra, in order.
+        let tree: Vec<SpineNode> = vertebrae
+            .iter()
+            .enumerate()
+            .map(|(i, v)| SpineNode {
+                segment: v.handle.clone(),
+                title: None,
+                vertebra: Some(i),
+                children: Vec::new(),
+            })
+            .collect();
+
+        debug_assert!(
+            {
+                let mut indices = Vec::new();
+                for node in &tree {
+                    node.collect_indices(&mut indices);
+                }
+                let unique: HashSet<usize> = indices.iter().copied().collect();
+                indices.len() == vertebrae.len() && unique.len() == indices.len()
+            },
+            "spine tree must reference every vertebra exactly once"
+        );
+
         Ok(Self {
-            vertebrae: vertebrae?,
+            vertebrae,
             layout,
+            tree,
         })
     }
 
@@ -565,6 +645,31 @@ mod tests {
     }
 
     #[test]
+    fn flat_accessor_matches_vertebrae_order() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let content = root.join("content");
+        fs::create_dir_all(&content).unwrap();
+        fs::write(content.join("intro.typ"), "= Intro\n").unwrap();
+        fs::write(content.join("closing.typ"), "= Closing\n").unwrap();
+
+        let files = vec![content.join("intro.typ"), content.join("closing.typ")];
+        let layout = SpineLayout::OnePerVertebra {
+            ext: "html".into(),
+            format: "html".into(),
+        };
+        let spine = VirtualSpine::build(&files, &content, root, layout).unwrap();
+
+        let expected: Vec<&str> = spine.vertebrae.iter().map(|v| v.handle.as_str()).collect();
+        let actual: Vec<&str> = spine
+            .flat_vertebrae()
+            .iter()
+            .map(|v| v.handle.as_str())
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn vertebra_retains_source() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
@@ -700,6 +805,7 @@ mod tests {
                 ext: "html".into(),
                 format: "html".into(),
             },
+            tree: Vec::new(),
         };
         let src = spine.source();
         assert!(src.contains("#document(\"intro.html\", format: \"html\""));
@@ -741,6 +847,7 @@ mod tests {
                 output_name: "doc.pdf".into(),
                 format: "pdf".into(),
             },
+            tree: Vec::new(),
         };
         let src = spine.source();
         assert!(src.contains("#document(\"doc.pdf\", format: \"pdf\""));
@@ -784,6 +891,7 @@ mod tests {
                 output_name: "book.pdf".into(),
                 format: "pdf".into(),
             },
+            tree: Vec::new(),
         };
         assert!(spine.check_output_collisions().is_ok());
     }

--- a/crates/core/src/util/typst_literal.rs
+++ b/crates/core/src/util/typst_literal.rs
@@ -13,6 +13,8 @@
 pub enum TypstLiteral {
     /// A string literal (escaped on serialize).
     Str(String),
+    /// The `none` literal.
+    None,
     /// An array literal, e.g. `(a, b,)`.
     Array(Vec<TypstLiteral>),
     /// A dictionary literal with identifier keys, e.g. `(k: v)`.
@@ -33,6 +35,7 @@ impl TypstLiteral {
     pub fn serialize(&self) -> String {
         match self {
             TypstLiteral::Str(s) => serialize_string(s),
+            TypstLiteral::None => "none".to_string(),
             TypstLiteral::Array(items) if items.is_empty() => "()".to_string(),
             TypstLiteral::Array(items) => {
                 let inner: Vec<String> = items.iter().map(TypstLiteral::serialize).collect();
@@ -55,6 +58,7 @@ impl TypstLiteral {
         use typst::foundations::{Array, Dict, Value};
         match self {
             TypstLiteral::Str(s) => Value::Str(s.as_str().into()),
+            TypstLiteral::None => Value::None,
             TypstLiteral::Array(items) => {
                 Value::Array(items.iter().map(TypstLiteral::to_value).collect::<Array>())
             }
@@ -104,6 +108,15 @@ mod tests {
     fn empty_array_and_dict_use_typst_syntax() {
         assert_eq!(TypstLiteral::Array(vec![]).serialize(), "()");
         assert_eq!(TypstLiteral::Dict(vec![]).serialize(), "(:)");
+    }
+
+    #[test]
+    fn none_serializes_and_converts_to_value_none() {
+        assert_eq!(TypstLiteral::None.serialize(), "none");
+        assert_eq!(
+            TypstLiteral::None.to_value(),
+            typst::foundations::Value::None
+        );
     }
 
     #[test]

--- a/crates/epub/src/lib.rs
+++ b/crates/epub/src/lib.rs
@@ -44,7 +44,7 @@ impl FormatPlugin for EpubPlugin {
     fn apply_defaults(&self, section: &mut PluginSection, project_name: &str) {
         let spine = section.spine.get_or_insert_with(|| Spine {
             title: None,
-            vertebrae: vec![],
+            ..Default::default()
         });
         if spine.title.is_none() {
             spine.title = Some(DocumentTitle::to_readable_name(project_name));

--- a/crates/epub/src/lib.rs
+++ b/crates/epub/src/lib.rs
@@ -9,7 +9,7 @@ use iref::{IriRef, IriRefBuf, iri::Fragment};
 use itertools::Itertools;
 use rheo_core::{
     CastVertebra, FormatInitTemplate, FormatPlugin, PluginContext, PluginSection, Result,
-    RheoError, Spine, SpineLayoutKind, SpineOptions, eco_format, eco_vec,
+    RheoError, Spine, SpineLayoutKind, eco_format, eco_vec,
 };
 use rheo_core::{DocumentTitle, EcoString, OutlineNode};
 use serde::Deserialize;
@@ -88,7 +88,7 @@ impl FormatPlugin for EpubPlugin {
         let nav_xhtml = generate_nav_xhtml(&mut items, &language)?;
         let package_string = generate_package(
             &items,
-            ctx.spine,
+            ctx.spine_title,
             identifier.as_deref(),
             date.as_ref(),
             &language,
@@ -181,17 +181,19 @@ fn date_format(dt: &DateTime<Utc>) -> EcoString {
 }
 
 /// Generates the package.opf XML string from the generated EPUB items.
+///
+/// `spine_title` takes the plain `Option<&str>` shape of `PluginContext::spine_title`
+/// (the title is the only part of the old `SpineOptions` any plugin ever read;
+/// the rest was a dead glob-pattern list removed with it) rather than a dedicated type.
 pub fn generate_package(
     items: &[EpubItem],
-    spine: &SpineOptions,
+    spine_title: Option<&str>,
     identifier: Option<&str>,
     date: Option<&DateTime<Utc>>,
     language: &str,
     author: Option<&str>,
 ) -> Result<String> {
-    let title = spine
-        .title
-        .as_deref()
+    let title = spine_title
         .map(EcoString::from)
         .unwrap_or_else(|| items[0].title());
 

--- a/crates/epub/src/lib.rs
+++ b/crates/epub/src/lib.rs
@@ -88,7 +88,7 @@ impl FormatPlugin for EpubPlugin {
         let nav_xhtml = generate_nav_xhtml(&mut items, &language)?;
         let package_string = generate_package(
             &items,
-            ctx.spine_title,
+            ctx.spine.title.as_deref(),
             identifier.as_deref(),
             date.as_ref(),
             &language,

--- a/crates/html/src/feed.rs
+++ b/crates/html/src/feed.rs
@@ -248,6 +248,7 @@ mod tests {
     #[test]
     fn test_feed_exclude_omits_entry() {
         use rheo_core::config::project::{ProjectConfig, ProjectMode};
+        use rheo_core::reticulate::{SpineLayout, SpineScan, VirtualSpine};
         use rheo_core::{PluginSection, RheoConfig, RheoValue, TypstFormat};
         use std::collections::HashMap;
         use typst::foundations::Bytes;
@@ -290,9 +291,17 @@ mod tests {
         let section = PluginSection::default();
         let assets = HashMap::new();
         let font_dirs: Vec<std::path::PathBuf> = vec![];
+        let layout = SpineLayout::OnePerVertebra {
+            ext: "html".into(),
+            format: "html".into(),
+        };
+        let virtual_spine =
+            VirtualSpine::build(SpineScan::flat(&[], &output_dir), &output_dir, layout)
+                .expect("build empty spine");
         let ctx = PluginContext {
             project: &project,
             output_dir: &output_dir,
+            spine: &virtual_spine,
             spine_title: None,
             config: &section,
             assets: &assets,

--- a/crates/html/src/feed.rs
+++ b/crates/html/src/feed.rs
@@ -302,7 +302,6 @@ mod tests {
             project: &project,
             output_dir: &output_dir,
             spine: &virtual_spine,
-            spine_title: None,
             config: &section,
             assets: &assets,
             font_dirs: &font_dirs,

--- a/crates/html/src/feed.rs
+++ b/crates/html/src/feed.rs
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn test_feed_exclude_omits_entry() {
         use rheo_core::config::project::{ProjectConfig, ProjectMode};
-        use rheo_core::{PluginSection, RheoConfig, RheoValue, SpineOptions, TypstFormat};
+        use rheo_core::{PluginSection, RheoConfig, RheoValue, TypstFormat};
         use std::collections::HashMap;
         use typst::foundations::Bytes;
 
@@ -287,17 +287,13 @@ mod tests {
             mode: ProjectMode::Directory,
             config_path: None,
         };
-        let spine = SpineOptions {
-            title: None,
-            vertebrae: vec![],
-        };
         let section = PluginSection::default();
         let assets = HashMap::new();
         let font_dirs: Vec<std::path::PathBuf> = vec![];
         let ctx = PluginContext {
             project: &project,
             output_dir: &output_dir,
-            spine: &spine,
+            spine_title: None,
             config: &section,
             assets: &assets,
             font_dirs: &font_dirs,

--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -122,7 +122,7 @@ impl FormatPlugin for HtmlPlugin {
             .unwrap_or_default();
 
         let html_cfg = ctx.config.parse_extra::<HtmlConfig>()?;
-        let feed_title = html_cfg.resolve_title(ctx.spine_title, &ctx.project.name);
+        let feed_title = html_cfg.resolve_title(ctx.spine.title.as_deref(), &ctx.project.name);
         let feed_link = html_cfg
             .base_url()
             .map(|base| (format!("{base}/feed.xml"), feed_title.clone()));

--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -122,7 +122,7 @@ impl FormatPlugin for HtmlPlugin {
             .unwrap_or_default();
 
         let html_cfg = ctx.config.parse_extra::<HtmlConfig>()?;
-        let feed_title = html_cfg.resolve_title(ctx.spine.title.as_deref(), &ctx.project.name);
+        let feed_title = html_cfg.resolve_title(ctx.spine_title, &ctx.project.name);
         let feed_link = html_cfg
             .base_url()
             .map(|base| (format!("{base}/feed.xml"), feed_title.clone()));


### PR DESCRIPTION
Replaces the flat `vertebrae` glob-list spine config with a directory-scan default plus `[spine] exclude` and `[[spine.section]]` virtual grouping, so spine membership no longer requires enumerating every file.

```toml
[spine]
exclude = ["drafts/**", "notes/**"]  # omitted from every format's scan

[[spine.section]]
name = "chapters"       # groups matched files under a virtual chapters/ node
include = ["ch-*.typ"]  # without moving them on disk
```

- `SpineScan` walks `content_dir` into a tree (`crates/core/src/reticulate/spine.rs`): subdirectories become nested nodes (`index.typ`/`<dirname>.typ` = clickable landing, otherwise a non-clickable group node with a prettified title), files become leaves, siblings ordered by name. `exclude` globs are matched with `globset::GlobSet`; `[[spine.section]]` regroups matched files under a virtual directory without moving them on disk, nesting via `[[spine.section.section]]`.
- `VirtualSpine::build` derives each handle from the file's position in the tree (ancestor segments joined by `:`) instead of a flat vertebrae list.
- Per-format `[<format>.spine]` merges with the global `[spine]` field-by-field — `title`/`exclude`/`section` are inherited individually rather than the whole table being replaced when a format sets any one of them (`crates/core/src/config/mod.rs`).
- `rheo-context.spine` becomes the structured tree; the old flat list moves to `rheo-context.spine-flat` (`crates/core/src/reticulate/mod.rs`, `crates/html/src/feed.rs`, `crates/epub/src/lib.rs`).
- The retired `vertebrae` field is dropped from `Spine`; a leftover key now warns instead of being silently ignored.
- Renames `@rheo/zettelkasten` to `@rheo/notebox` in docs to match the package's new name.

# Migration

`rheo migrate` converts an old `vertebrae` inclusion-filter glob list into an equivalent `[spine] exclude`, so a helper file the old list deliberately never named doesn't silently start being published now that scanning is on by default. When `vertebrae` matched every `.typ` file anyway, the key is dropped with no exclude added.