### PR TITLE
v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "rheo"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atty",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "rheo-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atty",
  "chrono",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "rheo-epub"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "iref",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "rheo-html"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atom_syndication",
  "axum",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "rheo-pdf"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "rheo-core",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/html", "crates/pdf", "crates/epub", "crates/cli"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Lachlan Kermode <lachie@ohrg.org>"]
 description = "A typesetting and static site engine based on Typst"
@@ -13,10 +13,10 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal crates (for convenience in workspace)
-rheo-core = { path = "crates/core", version = "0.4.0" }
-rheo-html = { path = "crates/html", version = "0.4.0" }
-rheo-pdf = { path = "crates/pdf", version = "0.4.0" }
-rheo-epub = { path = "crates/epub", version = "0.4.0" }
+rheo-core = { path = "crates/core", version = "0.5.0" }
+rheo-html = { path = "crates/html", version = "0.5.0" }
+rheo-pdf = { path = "crates/pdf", version = "0.5.0" }
+rheo-epub = { path = "crates/epub", version = "0.5.0" }
 
 # Typst dependencies
 typst = "0.15.0"


### PR DESCRIPTION
- Bumps workspace version 0.4.0 → 0.5.0 across all crates