### PR TITLE
Encapsulates `rheo-context()` behind a function boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,38 +107,41 @@ rheo assigns each vertebra a canonical label derived from its path relative to t
 
 ## rheo-context
 
-rheo injects a per-vertebra Typst variable `rheo-context` into every spine file, exposing rheo's view of the project to authored Typst and to packages. It is a plain top-level `#let` binding prepended to each file's source — an ordinary dictionary, **not** a Typst `context` value. Each vertebra gets its own values because rheo injects a distinct literal per file, not through Typst's context mechanism. Reading it therefore does **not** require the `#context` keyword:
+rheo injects a per-vertebra Typst binding `rheo-context()` into every spine file, exposing rheo's view of the project to authored Typst and to packages. It is a zero-arg **function** prepended to each file's source, returning a dictionary composed of this file's own `handle` plus the format-global values spread from `sys.inputs.rheo-context`: `#let rheo-context() = (handle: <handle>, ..sys.inputs.rheo-context)`. Only the per-file `handle` is baked per vertebra; the shared (potentially large) `spine` is stored once on `sys.inputs`, not duplicated into every file. `sys.inputs` reads need no `#context`, so reading its fields (`rheo-context().handle`) does **not** require the `#context` keyword. The function form also lets an author mock it under vanilla Typst.
 
-Fields (the value is a dictionary and may gain fields later):
-- `handle` — this file's `:`-separated handle (its ID; the same handle used for the cross-file links above).
+Fields (the returned dictionary may gain fields later):
+- `handle` — this file's `:`-separated handle (its ID; the same handle used for the cross-file links above). The only per-file field.
 - `spine` — the structured spine **tree**, mirroring directory/section nesting. Each node is a dict `(title, handle, path, children)`: a leaf (a vertebra) carries its own `handle`/`path`/`title`; a group node (a directory or `[[spine.section]]` with no landing file) carries `handle: none`, `path: none`, and its own group title, nesting its children.
-- `spine-flat` — the flat pre-order list of every *clickable* vertebra (groups excluded), each an entry `(handle, path, title)` — the same shape the old flat `spine` used to be.
-- `target` — the rheo output-format name (`"epub"`/`"html"`/…). Present only for formats that set one; **absent for PDF**, where documents fall back to Typst's native `target()` == `"paged"`. Identical across vertebrae, so it also rides on the global `sys.inputs.rheo-context`.
+- `spine-flat` — the flat pre-order list of every *clickable* vertebra (groups excluded), each an entry `(handle, path, title)`.
+- `target` — the rheo output-format name (`"epub"`/`"html"`/…). Present only for formats that set one; **absent for PDF**, where documents fall back to Typst's native `target()` == `"paged"`.
+- `ext` — the output file extension (`"html"`/`"xhtml"`), gated like `target` (present for html/epub, absent for PDF). The value core reads to build depth-relative cross-vertebra link hrefs.
+
+`spine`/`spine-flat`/`target`/`ext` are format-global (identical across vertebrae), stored once on `sys.inputs.rheo-context`; `rheo-context()` composes them with the per-file `handle`.
 
 ```typst
-This is #rheo-context.handle of #rheo-context.spine-flat.len() pages.
+This is #rheo-context().handle of #rheo-context().spine-flat.len() pages.
 ```
 
-**Passing it to packages:** a package template can't read the file's local `rheo-context` implicitly — Typst functions capture their definition scope, not the call site — so hand it in explicitly:
+**Passing it to packages:** a package template can't read the file's local `rheo-context()` implicitly — Typst functions capture their definition scope, not the call site — so hand it in explicitly:
 
 ```typst
 #import "@rheo/somepackage": template
-#show: template.with(ctx: rheo-context)
+#show: template.with(ctx: rheo-context())
 ```
 
-**Detecting a rheo build (for a friendly native-Typst error).** rheo also seeds `sys.inputs` with a `rheo-context` key carrying the file-independent context (the `spine`). Because `sys.inputs` is global to the whole bundle compile, it does **not** carry the per-file `handle` — that stays on the per-vertebra `#let rheo-context`. A package (or author) uses `sys.inputs` to detect a rheo build and turn native-Typst compilation into a friendly message, without tripping the unbound-variable error (`rheo-context` referenced inside an untaken `if` branch is never evaluated):
+**Detecting a rheo build (for a friendly native-Typst error).** rheo also seeds `sys.inputs` with a `rheo-context` key (a plain **data dict**, not a function) carrying the file-independent context (`spine`/`spine-flat`/`target`/`ext`). Because `sys.inputs` is global to the whole bundle compile, it does **not** carry the per-file `handle` — that comes from calling the per-vertebra `rheo-context()`. A package (or author) uses `sys.inputs` to detect a rheo build and turn native-Typst compilation into a friendly message:
 
 ```typst
-#show: template.with(ctx: if "rheo-context" in sys.inputs { rheo-context } else {
+#show: template.with(ctx: if "rheo-context" in sys.inputs { rheo-context() } else {
   panic("This document must be compiled with Rheo — https://rheo.ohrg.org")
 })
 ```
 
-A package needing only the shared spine can read `sys.inputs.rheo-context.spine` directly and never touch the per-file `#let`.
+A package needing only the shared spine can read `sys.inputs.rheo-context.spine` directly and never call the per-file `rheo-context()`. (`rheo migrate` rewrites the old bare `rheo-context` binding to the `rheo-context()` call form.)
 
 **Output format.** rheo injects a `target()` polyfill into every file so Typst's own `target()` returns the output format (`"epub"`/`"html"`, or native `"paged"` for PDF), reading it from `sys.inputs.rheo-context.target`. Authored files should detect the format with `target()` (e.g. `target() == "epub"`); it is the only per-file API. The underlying `sys.inputs.rheo-context.target` is the same value for every vertebra but is not in scope where the polyfill isn't (it is global, so reachable via `sys.inputs`). The older `sys.inputs.rheo-target` key has been **removed**.
 
-**Section-label namespacing is a package concern, not core.** rheo does not rewrite or prefix authored labels; label semantics stay exactly as Typst defines them (two vertebrae defining the same label collide as an ordinary Typst duplicate-label error). Packages such as `@rheo/notebox` use `rheo-context` to *additively* synthesize globally-unique `<handle:label>` section anchors alongside the author's own labels.
+**Section-label namespacing is a package concern, not core.** rheo does not rewrite or prefix authored labels; label semantics stay exactly as Typst defines them (two vertebrae defining the same label collide as an ordinary Typst duplicate-label error). Packages such as `@rheo/notebox` use `rheo-context()` to *additively* synthesize globally-unique `<handle:label>` section anchors alongside the author's own labels.
 
 ## Spine configuration
 

--- a/crates/cli/src/migrate.rs
+++ b/crates/cli/src/migrate.rs
@@ -79,6 +79,10 @@ pub fn migrate_project(path: &Path, apply: bool) -> Result<()> {
     // in the same release as the rheo-target removal above — same threshold.
     let needs_vertebrae_migration = from < to;
 
+    // The per-vertebra `rheo-context` binding became a function `rheo-context()`;
+    // any older project's references are rewritten.
+    let needs_context_rewrite = from < to;
+
     println!("\nMigrations:");
     if needs_link_rewrite {
         println!("  - rewrite #link(\"./file.typ\") syntax to #link(<handle>)");
@@ -90,6 +94,9 @@ pub fn migrate_project(path: &Path, apply: bool) -> Result<()> {
     }
     if needs_vertebrae_migration {
         println!("  - convert retired [spine] vertebrae glob lists to [spine] exclude");
+    }
+    if needs_context_rewrite {
+        println!("  - rewrite rheo-context -> rheo-context() (function form)");
     }
     println!("  - bump rheo.toml version to {to}");
 
@@ -106,6 +113,11 @@ pub fn migrate_project(path: &Path, apply: bool) -> Result<()> {
     if needs_vertebrae_migration {
         println!("\nSpine config:");
         migrate_vertebrae_to_exclude(&project, config_path, apply)?;
+    }
+
+    if needs_context_rewrite {
+        println!("\nContext references:");
+        migrate_context_references(&project, apply)?;
     }
 
     if apply {
@@ -282,6 +294,59 @@ fn migrate_target_references(project: &ProjectConfig, apply: bool) -> Result<()>
 
         if changed && apply {
             fs::write(file, content.as_bytes())
+                .map_err(|e| RheoError::io(e, format!("failed to write {}", file.display())))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Rewrite author references to the per-vertebra `rheo-context` binding into its
+/// zero-arg function form `rheo-context()` (the binding changed from a bare dict
+/// to a function).
+///
+/// Rewrites bare `rheo-context` tokens — `rheo-context.field`, `ctx: rheo-context`,
+/// `#let x = rheo-context` — to `rheo-context()`. Deliberately does NOT touch:
+/// - `sys.inputs.rheo-context` (the global data dict, still a value) — guarded by
+///   the preceding `.`;
+/// - the string literal `"rheo-context"` (build detection) — guarded by the
+///   surrounding quotes;
+/// - an already-converted `rheo-context()` call — guarded by the following `(`.
+///
+/// Rust's `regex` has no lookaround, so the single delimiter char on each side is
+/// captured (`pre`/`post`) and reinserted. `pre` excludes `.`/`"`/word/`-`; `post`
+/// excludes `(`/word/`-`; string boundaries (`^`/`$`) and newlines count as
+/// delimiters.
+fn migrate_context_references(project: &ProjectConfig, apply: bool) -> Result<()> {
+    let content_dir = resolve_effective_content_dir(project);
+    let typ_files = collect_typ_files(&content_dir);
+    if typ_files.is_empty() {
+        return Ok(());
+    }
+
+    let re = Regex::new(r#"(?P<pre>^|[^.\w"-])rheo-context(?P<post>$|[^\w(-])"#)
+        .expect("hardcoded context regex must compile");
+
+    for file in &typ_files {
+        let content = match fs::read_to_string(file) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(file = %file.display(), error = %e, "skipping unreadable file");
+                continue;
+            }
+        };
+        let mut hit = false;
+        let out = re.replace_all(&content, |caps: &Captures| -> String {
+            let line = line_number(&content, caps.get(0).unwrap().start());
+            let label = "rheo-context  ->  rheo-context()";
+            info!(file = %file.display(), line, rewrite = label, "rewrite context reference");
+            println!("{}:{}: {}", file.display(), line, label);
+            hit = true;
+            format!("{}rheo-context(){}", &caps["pre"], &caps["post"])
+        });
+
+        if hit && apply {
+            fs::write(file, out.as_bytes())
                 .map_err(|e| RheoError::io(e, format!("failed to write {}", file.display())))?;
         }
     }
@@ -647,6 +712,55 @@ mod tests {
         assert!(out.contains("{ sys.inputs.rheo-context.target }"));
         // No trace of the removed key/helper remains.
         assert!(!out.contains("rheo-target"));
+        // Unrelated content untouched.
+        assert!(out.contains("= Unrelated Title"));
+    }
+
+    #[test]
+    fn rewrite_replaces_context_references() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let content = root.join("content");
+        fs::create_dir_all(&content).unwrap();
+        fs::write(
+            content.join("page.typ"),
+            "#show: t.with(ctx: rheo-context)\n\
+             This is #rheo-context.handle of #rheo-context.spine-flat.len() pages.\n\
+             #if \"rheo-context\" in sys.inputs { sys.inputs.rheo-context.spine }\n\
+             = Unrelated Title\n",
+        )
+        .unwrap();
+
+        let project = ProjectConfig {
+            root: root.to_path_buf(),
+            name: "test".into(),
+            config: rheo_core::RheoConfig {
+                version: ManifestVersion::parse("0.5.0").unwrap(),
+                content_dir: Some("content".into()),
+                ..Default::default()
+            },
+            typ_files: vec![content.join("page.typ")],
+            mode: rheo_core::config::project::ProjectMode::Directory,
+            config_path: Some(root.join("rheo.toml")),
+        };
+        fs::write(
+            root.join("rheo.toml"),
+            "version = \"0.5.0\"\ncontent_dir = \"content\"\n",
+        )
+        .unwrap();
+
+        migrate_context_references(&project, true).unwrap();
+
+        let out = fs::read_to_string(content.join("page.typ")).unwrap();
+        // The per-file binding, passed and field-accessed, becomes a call.
+        assert!(out.contains("#show: t.with(ctx: rheo-context())"));
+        assert!(out.contains("#rheo-context().handle"));
+        assert!(out.contains("#rheo-context().spine-flat.len()"));
+        // The global data dict and the detection string literal are untouched.
+        assert!(out.contains("\"rheo-context\" in sys.inputs"));
+        assert!(out.contains("sys.inputs.rheo-context.spine"));
+        // No double-conversion.
+        assert!(!out.contains("rheo-context()()"));
         // Unrelated content untouched.
         assert!(out.contains("= Unrelated Title"));
     }

--- a/crates/cli/src/migrate.rs
+++ b/crates/cli/src/migrate.rs
@@ -96,7 +96,7 @@ pub fn migrate_project(path: &Path, apply: bool) -> Result<()> {
         println!("  - convert retired [spine] vertebrae glob lists to [spine] exclude");
     }
     if needs_context_rewrite {
-        println!("  - rewrite rheo-context -> rheo-context() (function form)");
+        println!("  - shim `rheo-context` binding for its new `rheo-context()` function form");
     }
     println!("  - bump rheo.toml version to {to}");
 
@@ -301,22 +301,28 @@ fn migrate_target_references(project: &ProjectConfig, apply: bool) -> Result<()>
     Ok(())
 }
 
-/// Rewrite author references to the per-vertebra `rheo-context` binding into its
-/// zero-arg function form `rheo-context()` (the binding changed from a bare dict
-/// to a function).
+/// The compatibility shim prepended to files that read the per-vertebra
+/// `rheo-context` binding, which changed from a bare dict to a zero-arg function
+/// `rheo-context()`.
+const CONTEXT_SHIM: &str = "#let rheo-context = rheo-context()";
+
+/// Keep authored files that read the per-vertebra `rheo-context` binding working
+/// after it changed from a bare dict to a function `rheo-context()`.
 ///
-/// Rewrites bare `rheo-context` tokens — `rheo-context.field`, `ctx: rheo-context`,
-/// `#let x = rheo-context` — to `rheo-context()`. Deliberately does NOT touch:
-/// - `sys.inputs.rheo-context` (the global data dict, still a value) — guarded by
-///   the preceding `.`;
-/// - the string literal `"rheo-context"` (build detection) — guarded by the
-///   surrounding quotes;
-/// - an already-converted `rheo-context()` call — guarded by the following `(`.
+/// Rather than rewrite every reference (a `rheo-context` identifier also appears
+/// as a label `<rheo-context>`, a ref `@rheo-context`, a raw span, a `.rheo-context`
+/// field, and a `"rheo-context"` string — regex can't safely splice `()` into all
+/// those), this prepends a one-line shim, `#let rheo-context = rheo-context()`,
+/// to each file that reads the binding. The shim calls the injected function once
+/// and rebinds the name to its dict, so existing `rheo-context.field` /
+/// `ctx: rheo-context` code keeps working untouched.
 ///
-/// Rust's `regex` has no lookaround, so the single delimiter char on each side is
-/// captured (`pre`/`post`) and reinserted. `pre` excludes `.`/`"`/word/`-`; `post`
-/// excludes `(`/word/`-`; string boundaries (`^`/`$`) and newlines count as
-/// delimiters.
+/// The detection regex only decides *whether* a file needs the shim (a false
+/// positive would add a harmless extra shim, so it errs toward precision without
+/// needing to be exact). It matches a `rheo-context` value reference: `pre`
+/// excludes the lead-in chars of the non-binding forms — `.` (`sys.inputs.rheo-context`
+/// field), `"` (string), `<` (label), `@` (ref), a backtick (raw span), and word/`-`
+/// (a longer identifier); `post` excludes `(` (already a call) and word/`-`.
 fn migrate_context_references(project: &ProjectConfig, apply: bool) -> Result<()> {
     let content_dir = resolve_effective_content_dir(project);
     let typ_files = collect_typ_files(&content_dir);
@@ -324,7 +330,7 @@ fn migrate_context_references(project: &ProjectConfig, apply: bool) -> Result<()
         return Ok(());
     }
 
-    let re = Regex::new(r#"(?P<pre>^|[^.\w"-])rheo-context(?P<post>$|[^\w(-])"#)
+    let re = Regex::new(r#"(?:^|[^.\w"<@`-])rheo-context(?:$|[^\w(-])"#)
         .expect("hardcoded context regex must compile");
 
     for file in &typ_files {
@@ -335,18 +341,18 @@ fn migrate_context_references(project: &ProjectConfig, apply: bool) -> Result<()
                 continue;
             }
         };
-        let mut hit = false;
-        let out = re.replace_all(&content, |caps: &Captures| -> String {
-            let line = line_number(&content, caps.get(0).unwrap().start());
-            let label = "rheo-context  ->  rheo-context()";
-            info!(file = %file.display(), line, rewrite = label, "rewrite context reference");
-            println!("{}:{}: {}", file.display(), line, label);
-            hit = true;
-            format!("{}rheo-context(){}", &caps["pre"], &caps["post"])
-        });
+        // Already shimmed (e.g. a re-run) or no binding use: nothing to do.
+        if content.contains(CONTEXT_SHIM) || !re.is_match(&content) {
+            continue;
+        }
 
-        if hit && apply {
-            fs::write(file, out.as_bytes())
+        let label = "prepend `#let rheo-context = rheo-context()` compatibility shim";
+        info!(file = %file.display(), rewrite = label, "shim context binding");
+        println!("{}: {}", file.display(), label);
+
+        if apply {
+            let shimmed = format!("{CONTEXT_SHIM}\n{content}");
+            fs::write(file, shimmed.as_bytes())
                 .map_err(|e| RheoError::io(e, format!("failed to write {}", file.display())))?;
         }
     }
@@ -717,17 +723,27 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_replaces_context_references() {
+    fn shims_files_that_read_the_context_binding() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         let content = root.join("content");
         fs::create_dir_all(&content).unwrap();
+        // A file that reads the binding, alongside a label, a ref, a raw span,
+        // the global dict, and the detection string — none of which must change.
         fs::write(
             content.join("page.typ"),
             "#show: t.with(ctx: rheo-context)\n\
              This is #rheo-context.handle of #rheo-context.spine-flat.len() pages.\n\
              #if \"rheo-context\" in sys.inputs { sys.inputs.rheo-context.spine }\n\
+             See #link(<rheo-context>)[the page], @rheo-context, and `rheo-context.target`.\n\
              = Unrelated Title\n",
+        )
+        .unwrap();
+        // A file that only links to / mentions the handle (label + global dict),
+        // never reading the binding value — must NOT be shimmed.
+        fs::write(
+            content.join("link_only.typ"),
+            "See #link(<rheo-context>)[the context page]; sys.inputs.rheo-context.spine.\n",
         )
         .unwrap();
 
@@ -739,7 +755,7 @@ mod tests {
                 content_dir: Some("content".into()),
                 ..Default::default()
             },
-            typ_files: vec![content.join("page.typ")],
+            typ_files: vec![content.join("page.typ"), content.join("link_only.typ")],
             mode: rheo_core::config::project::ProjectMode::Directory,
             config_path: Some(root.join("rheo.toml")),
         };
@@ -752,17 +768,22 @@ mod tests {
         migrate_context_references(&project, true).unwrap();
 
         let out = fs::read_to_string(content.join("page.typ")).unwrap();
-        // The per-file binding, passed and field-accessed, becomes a call.
-        assert!(out.contains("#show: t.with(ctx: rheo-context())"));
-        assert!(out.contains("#rheo-context().handle"));
-        assert!(out.contains("#rheo-context().spine-flat.len()"));
-        // The global data dict and the detection string literal are untouched.
+        // The shim is prepended once, ahead of the body.
+        assert!(out.starts_with("#let rheo-context = rheo-context()\n"));
+        assert_eq!(out.matches("#let rheo-context = rheo-context()").count(), 1);
+        // Every original reference is left exactly as written — nothing rewritten.
+        assert!(out.contains("#show: t.with(ctx: rheo-context)\n"));
+        assert!(out.contains("#rheo-context.handle of #rheo-context.spine-flat.len()"));
         assert!(out.contains("\"rheo-context\" in sys.inputs"));
         assert!(out.contains("sys.inputs.rheo-context.spine"));
-        // No double-conversion.
-        assert!(!out.contains("rheo-context()()"));
-        // Unrelated content untouched.
+        assert!(out.contains("#link(<rheo-context>)"));
+        assert!(out.contains("@rheo-context,"));
+        assert!(out.contains("`rheo-context.target`"));
         assert!(out.contains("= Unrelated Title"));
+
+        // The link-only file reads no binding value, so it is left untouched.
+        let link_only = fs::read_to_string(content.join("link_only.typ")).unwrap();
+        assert!(!link_only.contains(CONTEXT_SHIM));
     }
 
     #[test]

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -216,7 +216,12 @@ impl Build {
         virtual_spine.check_output_collisions()?;
 
         let moulded = virtual_spine.mould();
-        let rheo_context = virtual_spine.rheo_context_preludes(plugin.rheo_target());
+        // `ext` rides on rheo-context alongside `target` (present for per-page
+        // plugin formats, omitted for the combined PDF) so typ/rheo.typ can build
+        // cross-vertebra hrefs without hardcoding the extension.
+        let target = plugin.rheo_target();
+        let ext = target.map(|_| plugin.extension());
+        let rheo_context = virtual_spine.rheo_context_preludes(target, ext);
 
         // Single Typst bundle compile for this plugin.
         let world = RheoWorld::new_for_bundle(
@@ -224,7 +229,7 @@ impl Build {
             moulded.main,
             moulded.sources,
             rheo_context,
-            Some(virtual_spine.global_context(plugin.rheo_target())),
+            Some(virtual_spine.global_context(target, ext)),
             plugin.rheo_target(),
             self.font_dirs.clone(),
         )?;

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -221,7 +221,7 @@ impl Build {
         // cross-vertebra hrefs without hardcoding the extension.
         let target = plugin.rheo_target();
         let ext = target.map(|_| plugin.extension());
-        let rheo_context = virtual_spine.rheo_context_preludes(target, ext);
+        let rheo_context = virtual_spine.rheo_context_preludes();
 
         // Single Typst bundle compile for this plugin.
         let world = RheoWorld::new_for_bundle(

--- a/crates/core/src/parser/rheo_var.rs
+++ b/crates/core/src/parser/rheo_var.rs
@@ -70,6 +70,14 @@ impl RheoVar {
             .find(|c| c.kind() == SyntaxKind::Ident)?;
         let key = name.leaf_text().strip_prefix("rheo-")?;
 
+        // `rheo-context` is rheo's reserved per-vertebra binding, not a
+        // harvestable `rheo-<key>` variable — its value is a dict/function, not a
+        // string/boolean literal. Skip it so a `#let rheo-context = ...` (e.g. the
+        // `rheo migrate` compatibility shim) is not mis-harvested and rejected.
+        if key == "context" {
+            return None;
+        }
+
         // The value is the first meaningful node after `=` (skipping whitespace).
         // String and boolean literals are supported; any other RHS yields `None`.
         let value = let_binding

--- a/crates/core/src/reticulate/bundle_source.rs
+++ b/crates/core/src/reticulate/bundle_source.rs
@@ -21,6 +21,10 @@ pub struct BundleDocument {
     pub output_path: String,
     pub format: String,
     pub title: String,
+    /// The `:`-joined handle of this document's page, published per-document via
+    /// Typst `state` so `typ/rheo.typ`'s cross-vertebra link rule can read the
+    /// current page's handle (empty for the combined PDF, which has no rule).
+    pub handle: String,
     /// Vertebra segments, in order. Each segment's anchors are emitted immediately
     /// before its include so cross-references resolve to the right location.
     pub segments: Vec<BundleSegment>,
@@ -42,6 +46,9 @@ impl fmt::Display for BundleSource {
                 "#document(\"{}\", format: \"{}\", title: [{escaped_title}])[",
                 doc.output_path, doc.format
             )?;
+            // Publish this page's handle so the link rule in typ/rheo.typ can read
+            // it via `state("rheo-handle").get()` to compute depth-relative hrefs.
+            writeln!(f, "  #state(\"rheo-handle\").update(\"{}\")", doc.handle)?;
             for segment in &doc.segments {
                 for anchor in &segment.anchors {
                     let escaped = escape_typst_content(&anchor.title);

--- a/crates/core/src/reticulate/bundle_source.rs
+++ b/crates/core/src/reticulate/bundle_source.rs
@@ -1,5 +1,11 @@
-use crate::util::path::escape_typst_content;
+use crate::util::typst_literal::TypstLiteral;
+use crate::util::typst_source::TypstStmt;
 use std::fmt;
+
+/// Typst `state` key carrying the current page's handle, published per-document
+/// so `typ/rheo.typ`'s cross-vertebra link rule can read it (see the rule and
+/// [`BundleDocument::to_stmt`]).
+const HANDLE_STATE_KEY: &str = "rheo-handle";
 
 /// A handle anchor emitted into a `BundleDocument` body so that `@label` cross-references
 /// resolve across vertebrae during bundle compilation.
@@ -40,29 +46,40 @@ pub struct BundleSource {
 impl fmt::Display for BundleSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for doc in &self.documents {
-            let escaped_title = escape_typst_content(&doc.title);
-            writeln!(
-                f,
-                "#document(\"{}\", format: \"{}\", title: [{escaped_title}])[",
-                doc.output_path, doc.format
-            )?;
-            // Publish this page's handle so the link rule in typ/rheo.typ can read
-            // it via `state("rheo-handle").get()` to compute depth-relative hrefs.
-            writeln!(f, "  #state(\"rheo-handle\").update(\"{}\")", doc.handle)?;
-            for segment in &doc.segments {
-                for anchor in &segment.anchors {
-                    let escaped = escape_typst_content(&anchor.title);
-                    writeln!(
-                        f,
-                        "  #figure([{escaped}], kind: \"rheo-handle\", supplement: none) <{}>",
-                        anchor.label
-                    )?;
-                }
-                writeln!(f, "  #include \"{}\"", segment.include)?;
-            }
-            writeln!(f, "]")?;
+            // Each document renders itself as a systematic `TypstStmt::Document`;
+            // a blank line separates successive documents.
+            writeln!(f, "{}", doc.to_stmt())?;
             writeln!(f)?;
         }
         Ok(())
+    }
+}
+
+impl BundleDocument {
+    /// Render this document as a [`TypstStmt::Document`]: a per-page handle
+    /// `state` update, then each segment's handle anchors followed by its
+    /// `#include`, in order.
+    fn to_stmt(&self) -> TypstStmt {
+        let mut body = vec![TypstStmt::StateUpdate {
+            key: HANDLE_STATE_KEY.to_string(),
+            value: TypstLiteral::str(self.handle.as_str()),
+        }];
+        for segment in &self.segments {
+            for anchor in &segment.anchors {
+                body.push(TypstStmt::HandleAnchor {
+                    label: anchor.label.clone(),
+                    title: anchor.title.clone(),
+                });
+            }
+            body.push(TypstStmt::Include {
+                path: segment.include.clone(),
+            });
+        }
+        TypstStmt::Document {
+            output_path: self.output_path.clone(),
+            format: self.format.clone(),
+            title: self.title.clone(),
+            body,
+        }
     }
 }

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -799,47 +799,20 @@ impl VirtualSpine {
 
     /// Per-vertebra `rheo-context` Typst preludes, keyed by include path (`rel_path`).
     ///
-    /// Each vertebra is injected with `#let rheo-context = (handle: <its handle>,
-    /// spine: <tree>, spine-flat: <flat list>)` so package templates can read the
-    /// file's own handle plus the spine, either as the structural tree or as a
-    /// flat pre-order list. The `handle` varies per file; `spine`/`spine-flat` are
-    /// identical across files. The shape is a dictionary so attributes can be
-    /// added later (e.g. by format plugins) without breaking consumers.
-    ///
-    /// Node key set for `spine` (recursive): `title` (str), `handle` (str or
-    /// `none`), `path` (str or `none`), `children` (array of nodes). A leaf
-    /// (`vertebra: Some`) carries its vertebra's `handle`/`path`/`title`; a group
-    /// node (`vertebra: None`, e.g. a directory or `[[spine.section]]` with no
-    /// landing file) carries `handle: none, path: none` and its own group title.
-    ///
-    /// `target` is the output-format name (e.g. `"html"`/`"epub"`); when
-    /// `Some`, a `target` field is added to the dict, and when `None` (PDF) it
-    /// is omitted so consumers fall back to Typst's native `target()`.
-    pub fn rheo_context_preludes(
-        &self,
-        target: Option<&str>,
-        ext: Option<&str>,
-    ) -> HashMap<String, String> {
-        let spine = self.spine_tree();
-        let spine_flat = self.spine_flat();
+    /// Each vertebra is injected with a `rheo-context()` function that composes
+    /// this file's own `handle` with the format-global values (`spine`,
+    /// `spine-flat`, `target`, `ext`) spread from `sys.inputs.rheo-context`:
+    /// `#let rheo-context() = (handle: <its handle>, ..sys.inputs.rheo-context)`.
+    /// Only the per-file `handle` is baked here; the shared (potentially large)
+    /// spine lives once in [`Self::global_context`], not duplicated per vertebra.
+    /// `sys.inputs` reads need no `#context`, so authors read `rheo-context()`
+    /// fields directly.
+    pub fn rheo_context_preludes(&self) -> HashMap<String, String> {
         self.vertebrae
             .iter()
             .map(|v| {
-                let mut fields = vec![
-                    ("handle".to_string(), TypstLiteral::str(v.handle.as_str())),
-                    ("spine".to_string(), spine.clone()),
-                    ("spine-flat".to_string(), spine_flat.clone()),
-                ];
-                if let Some(t) = target {
-                    fields.push(("target".to_string(), TypstLiteral::str(t)));
-                }
-                if let Some(e) = ext {
-                    fields.push(("ext".to_string(), TypstLiteral::str(e)));
-                }
-                let context = TypstLiteral::Dict(fields);
-                let binding = TypstStmt::Let {
-                    name: "rheo-context".to_string(),
-                    value: context,
+                let binding = TypstStmt::ContextBinding {
+                    handle: v.handle.clone(),
                 };
                 (v.rel_path.clone(), format!("{binding}\n\n"))
             })
@@ -1129,7 +1102,7 @@ mod tests {
     }
 
     #[test]
-    fn rheo_context_prelude_carries_handle_and_full_spine() {
+    fn rheo_context_prelude_is_composed_function_with_own_handle() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         let content = root.join("content");
@@ -1145,22 +1118,23 @@ mod tests {
         };
         let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
-        let preludes = spine.rheo_context_preludes(Some("html"), Some("html"));
+        let preludes = spine.rheo_context_preludes();
         // One prelude per vertebra, keyed by include path.
         assert_eq!(preludes.len(), 2);
         let root_prelude = &preludes["content/intro.typ"];
         let nested_prelude = &preludes["content/chapters/intro.typ"];
 
-        // Each carries its OWN handle...
+        // Each bakes only its OWN handle...
         assert!(root_prelude.contains("handle: \"intro\""));
         assert!(nested_prelude.contains("handle: \"chapters:intro\""));
-        // ...and the full flat spine (both vertebrae, with path), both as the
-        // tree (`spine`) and the flat pre-order list (`spine-flat`).
         for p in [root_prelude, nested_prelude] {
-            assert!(p.starts_with("#let rheo-context = "));
-            assert!(p.contains("spine-flat"));
-            assert!(p.contains("path: \"content/intro.typ\""));
-            assert!(p.contains("path: \"content/chapters/intro.typ\""));
+            // ...as a function that spreads the format-global values from
+            // sys.inputs (composed, not baked)...
+            assert!(p.starts_with("#let rheo-context() = "));
+            assert!(p.contains("..sys.inputs.rheo-context"));
+            // ...so the large spine is NOT duplicated into the per-file prelude.
+            assert!(!p.contains("spine-flat"));
+            assert!(!p.contains("path:"));
         }
     }
 
@@ -1215,24 +1189,20 @@ mod tests {
         };
         let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
-        // Some(target)/Some(ext) -> `target` and `ext` fields in both prelude
-        // and global context.
-        let with = spine.rheo_context_preludes(Some("html"), Some("html"));
-        assert!(with["content/intro.typ"].contains("target: \"html\""));
-        assert!(with["content/intro.typ"].contains("ext: \"html\""));
-        let global_with = spine.global_context(Some("html"), Some("html")).serialize();
-        assert!(global_with.contains("target: \"html\""));
-        assert!(global_with.contains("ext: \"html\""));
+        // target/ext live on the global context (sys.inputs); the per-file
+        // prelude only spreads them in, so they are asserted on global_context.
+        let global_html = spine.global_context(Some("html"), Some("html")).serialize();
+        assert!(global_html.contains("target: \"html\""));
+        assert!(global_html.contains("ext: \"html\""));
 
         // Epub keeps `target` "epub" but `ext` "xhtml".
-        let epub = spine.rheo_context_preludes(Some("epub"), Some("xhtml"));
-        assert!(epub["content/intro.typ"].contains("target: \"epub\""));
-        assert!(epub["content/intro.typ"].contains("ext: \"xhtml\""));
+        let global_epub = spine
+            .global_context(Some("epub"), Some("xhtml"))
+            .serialize();
+        assert!(global_epub.contains("target: \"epub\""));
+        assert!(global_epub.contains("ext: \"xhtml\""));
 
-        // None (PDF) -> no `target` or `ext` field anywhere.
-        let without = spine.rheo_context_preludes(None, None);
-        assert!(!without["content/intro.typ"].contains("target:"));
-        assert!(!without["content/intro.typ"].contains("ext:"));
+        // None (PDF) -> no `target` or `ext` field.
         let global_without = spine.global_context(None, None).serialize();
         assert!(!global_without.contains("target:"));
         assert!(!global_without.contains("ext:"));

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -12,41 +12,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use typst::syntax::Source;
 
-/// Typst `#show link` rule injected into every plugin-format (html/epub)
-/// vertebra prelude, after its `#let rheo-context`.
-///
-/// It rewrites `#link(<handle>)[text]` cross-vertebra links (only those whose
-/// target is a rheo-synthesized `rheo-handle` figure — authored labels pass
-/// through untouched) into a per-format href. The href is **depth-relative** to
-/// the current page: the handle's `:` separators become `/`, and a `../` prefix
-/// is prepended once per level the current page (`rheo-context.handle`) is
-/// nested, so a page at `chapters/ch1.html` links to `<intro>` as
-/// `../intro.html` and to `<chapters:ch2>` as `../chapters/ch2.html`. The
-/// redundant `#handle` fragment is dropped — the anchor sits at the top of the
-/// target page. Depends on `rheo-context.handle` and the `target()` polyfill
-/// being in scope, which the prelude and world both guarantee.
-const RHEO_LINK_SHOW_RULE: &str = r#"#show link: it => context {
-  if type(it.dest) == label {
-    let matches = query(it.dest)
-    if matches.len() > 0 {
-      let elem = matches.first()
-      if elem.func() == figure and elem.kind == "rheo-handle" {
-        let fmt = target()
-        let ext = if fmt == "epub" { ".xhtml" } else if fmt == "html" { ".html" } else { none }
-        if ext != none {
-          let handle = repr(it.dest).slice(1, -1)
-          let depth = rheo-context.handle.split(":").len() - 1
-          let prefix = if depth == 0 { "./" } else { range(depth).map(x => "../").join() }
-          return link(prefix + handle.replace(":", "/") + ext, it.body)
-        }
-      }
-    }
-  }
-  it
-}
-
-"#;
-
 // ── Directory scan: SpineScan ────────────────────────────────────────────────
 
 /// A content directory scanned into a structured spine tree.
@@ -849,7 +814,11 @@ impl VirtualSpine {
     /// `target` is the output-format name (e.g. `"html"`/`"epub"`); when
     /// `Some`, a `target` field is added to the dict, and when `None` (PDF) it
     /// is omitted so consumers fall back to Typst's native `target()`.
-    pub fn rheo_context_preludes(&self, target: Option<&str>) -> HashMap<String, String> {
+    pub fn rheo_context_preludes(
+        &self,
+        target: Option<&str>,
+        ext: Option<&str>,
+    ) -> HashMap<String, String> {
         let spine = self.spine_tree();
         let spine_flat = self.spine_flat();
         self.vertebrae
@@ -863,17 +832,11 @@ impl VirtualSpine {
                 if let Some(t) = target {
                     fields.push(("target".to_string(), TypstLiteral::str(t)));
                 }
-                let context = TypstLiteral::Dict(fields);
-                let mut prelude = format!("#let rheo-context = {}\n\n", context.serialize());
-                // For plugin formats (html/epub) append a #show link rule that
-                // rewrites #link(<handle>) cross-vertebra links into a depth-
-                // relative href. It reads this file's own rheo-context.handle to
-                // count how deep the page sits, so a nested page links out
-                // correctly (e.g. "../intro.html"). PDF (target None) keeps
-                // Typst's native link handling.
-                if target.is_some() {
-                    prelude.push_str(RHEO_LINK_SHOW_RULE);
+                if let Some(e) = ext {
+                    fields.push(("ext".to_string(), TypstLiteral::str(e)));
                 }
+                let context = TypstLiteral::Dict(fields);
+                let prelude = format!("#let rheo-context = {}\n\n", context.serialize());
                 (v.rel_path.clone(), prelude)
             })
             .collect()
@@ -887,15 +850,20 @@ impl VirtualSpine {
     /// the shared spine) without referencing the per-file `#let rheo-context`,
     /// which additionally carries this file's `handle`.
     ///
-    /// `target` follows the same rule as [`Self::rheo_context_preludes`]: a
-    /// `target` field is added when `Some`, omitted for PDF (`None`).
-    pub fn global_context(&self, target: Option<&str>) -> TypstLiteral {
+    /// `target` and `ext` follow the same rule as [`Self::rheo_context_preludes`]:
+    /// each field is added when `Some`, omitted for PDF (`None`). `ext` is the
+    /// output file extension (e.g. `"html"`/`"xhtml"`) — the value `typ/rheo.typ`
+    /// reads to build cross-vertebra link hrefs.
+    pub fn global_context(&self, target: Option<&str>, ext: Option<&str>) -> TypstLiteral {
         let mut fields = vec![
             ("spine".to_string(), self.spine_tree()),
             ("spine-flat".to_string(), self.spine_flat()),
         ];
         if let Some(t) = target {
             fields.push(("target".to_string(), TypstLiteral::str(t)));
+        }
+        if let Some(e) = ext {
+            fields.push(("ext".to_string(), TypstLiteral::str(e)));
         }
         TypstLiteral::Dict(fields)
     }
@@ -1016,6 +984,7 @@ impl VirtualSpine {
                     output_path: v.output_path.clone(),
                     format: format.clone(),
                     title: v.title.clone(),
+                    handle: v.handle.clone(),
                     segments: vec![segment_for(v)],
                 })
                 .collect(),
@@ -1033,6 +1002,9 @@ impl VirtualSpine {
                     output_path: output_name.clone(),
                     format: format.clone(),
                     title,
+                    // Combined PDF is one document with no cross-vertebra link
+                    // rule; the handle is unused.
+                    handle: String::new(),
                     segments: self.vertebrae.iter().map(segment_for).collect(),
                 }]
             }
@@ -1169,7 +1141,7 @@ mod tests {
         };
         let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
-        let preludes = spine.rheo_context_preludes(Some("html"));
+        let preludes = spine.rheo_context_preludes(Some("html"), Some("html"));
         // One prelude per vertebra, keyed by include path.
         assert_eq!(preludes.len(), 2);
         let root_prelude = &preludes["content/intro.typ"];
@@ -1225,7 +1197,7 @@ mod tests {
     }
 
     #[test]
-    fn rheo_context_target_present_when_some_absent_when_none() {
+    fn rheo_context_target_and_ext_present_when_some_absent_when_none() {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         let content = root.join("content");
@@ -1239,20 +1211,27 @@ mod tests {
         };
         let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
 
-        // Some(target) -> `target` field in both prelude and global context.
-        let with = spine.rheo_context_preludes(Some("html"));
+        // Some(target)/Some(ext) -> `target` and `ext` fields in both prelude
+        // and global context.
+        let with = spine.rheo_context_preludes(Some("html"), Some("html"));
         assert!(with["content/intro.typ"].contains("target: \"html\""));
-        assert!(
-            spine
-                .global_context(Some("html"))
-                .serialize()
-                .contains("target: \"html\"")
-        );
+        assert!(with["content/intro.typ"].contains("ext: \"html\""));
+        let global_with = spine.global_context(Some("html"), Some("html")).serialize();
+        assert!(global_with.contains("target: \"html\""));
+        assert!(global_with.contains("ext: \"html\""));
 
-        // None (PDF) -> no `target` field anywhere.
-        let without = spine.rheo_context_preludes(None);
+        // Epub keeps `target` "epub" but `ext` "xhtml".
+        let epub = spine.rheo_context_preludes(Some("epub"), Some("xhtml"));
+        assert!(epub["content/intro.typ"].contains("target: \"epub\""));
+        assert!(epub["content/intro.typ"].contains("ext: \"xhtml\""));
+
+        // None (PDF) -> no `target` or `ext` field anywhere.
+        let without = spine.rheo_context_preludes(None, None);
         assert!(!without["content/intro.typ"].contains("target:"));
-        assert!(!spine.global_context(None).serialize().contains("target:"));
+        assert!(!without["content/intro.typ"].contains("ext:"));
+        let global_without = spine.global_context(None, None).serialize();
+        assert!(!global_without.contains("target:"));
+        assert!(!global_without.contains("ext:"));
     }
 
     #[test]

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -5,6 +5,7 @@ use crate::reticulate::bundle_source::BundleSource;
 use crate::util::path::{sanitize_handle_segment, to_forward_slash};
 use crate::util::pdf::DocumentTitle;
 use crate::util::typst_literal::TypstLiteral;
+use crate::util::typst_source::TypstStmt;
 use crate::{Result, RheoError, TYP_EXT};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use std::collections::{HashMap, HashSet};
@@ -836,8 +837,11 @@ impl VirtualSpine {
                     fields.push(("ext".to_string(), TypstLiteral::str(e)));
                 }
                 let context = TypstLiteral::Dict(fields);
-                let prelude = format!("#let rheo-context = {}\n\n", context.serialize());
-                (v.rel_path.clone(), prelude)
+                let binding = TypstStmt::Let {
+                    name: "rheo-context".to_string(),
+                    value: context,
+                };
+                (v.rel_path.clone(), format!("{binding}\n\n"))
             })
             .collect()
     }

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -12,6 +12,41 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use typst::syntax::Source;
 
+/// Typst `#show link` rule injected into every plugin-format (html/epub)
+/// vertebra prelude, after its `#let rheo-context`.
+///
+/// It rewrites `#link(<handle>)[text]` cross-vertebra links (only those whose
+/// target is a rheo-synthesized `rheo-handle` figure — authored labels pass
+/// through untouched) into a per-format href. The href is **depth-relative** to
+/// the current page: the handle's `:` separators become `/`, and a `../` prefix
+/// is prepended once per level the current page (`rheo-context.handle`) is
+/// nested, so a page at `chapters/ch1.html` links to `<intro>` as
+/// `../intro.html` and to `<chapters:ch2>` as `../chapters/ch2.html`. The
+/// redundant `#handle` fragment is dropped — the anchor sits at the top of the
+/// target page. Depends on `rheo-context.handle` and the `target()` polyfill
+/// being in scope, which the prelude and world both guarantee.
+const RHEO_LINK_SHOW_RULE: &str = r#"#show link: it => context {
+  if type(it.dest) == label {
+    let matches = query(it.dest)
+    if matches.len() > 0 {
+      let elem = matches.first()
+      if elem.func() == figure and elem.kind == "rheo-handle" {
+        let fmt = target()
+        let ext = if fmt == "epub" { ".xhtml" } else if fmt == "html" { ".html" } else { none }
+        if ext != none {
+          let handle = repr(it.dest).slice(1, -1)
+          let depth = rheo-context.handle.split(":").len() - 1
+          let prefix = if depth == 0 { "./" } else { range(depth).map(x => "../").join() }
+          return link(prefix + handle.replace(":", "/") + ext, it.body)
+        }
+      }
+    }
+  }
+  it
+}
+
+"#;
+
 // ── Directory scan: SpineScan ────────────────────────────────────────────────
 
 /// A content directory scanned into a structured spine tree.
@@ -680,7 +715,13 @@ impl VirtualSpine {
                 let escape = format!("{handle}.typ");
 
                 let output_path = match &layout {
-                    SpineLayout::OnePerVertebra { ext, .. } => format!("{handle}.{ext}"),
+                    // The handle joins nesting with ':' (a valid Typst label
+                    // char; '/' is not). output_path is a real file path, so
+                    // translate those separators back to '/' — nested vertebrae
+                    // land in on-disk subdirectories, not colon-flattened files.
+                    SpineLayout::OnePerVertebra { ext, .. } => {
+                        format!("{}.{ext}", handle.replace(':', "/"))
+                    }
                     SpineLayout::SingleCombined { output_name, .. } => output_name.clone(),
                 };
 
@@ -823,7 +864,16 @@ impl VirtualSpine {
                     fields.push(("target".to_string(), TypstLiteral::str(t)));
                 }
                 let context = TypstLiteral::Dict(fields);
-                let prelude = format!("#let rheo-context = {}\n\n", context.serialize());
+                let mut prelude = format!("#let rheo-context = {}\n\n", context.serialize());
+                // For plugin formats (html/epub) append a #show link rule that
+                // rewrites #link(<handle>) cross-vertebra links into a depth-
+                // relative href. It reads this file's own rheo-context.handle to
+                // count how deep the page sits, so a nested page links out
+                // correctly (e.g. "../intro.html"). PDF (target None) keeps
+                // Typst's native link handling.
+                if target.is_some() {
+                    prelude.push_str(RHEO_LINK_SHOW_RULE);
+                }
                 (v.rel_path.clone(), prelude)
             })
             .collect()
@@ -1033,6 +1083,28 @@ mod tests {
         assert_eq!(spine.vertebrae[0].output_path, "intro.html");
         assert_eq!(spine.vertebrae[1].handle, "closing");
         assert_eq!(spine.vertebrae[1].output_path, "closing.html");
+    }
+
+    #[test]
+    fn nested_handle_maps_to_slash_output_path() {
+        // The handle joins nesting with ':' (a valid Typst label char), but the
+        // per-vertebra output_path is a real file path, so nested vertebrae must
+        // land in on-disk subdirectories: handle "pages:about" → "pages/about.html".
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let content = root.join("content");
+        fs::create_dir_all(content.join("pages")).unwrap();
+        fs::write(content.join("pages").join("about.typ"), "= About\n").unwrap();
+
+        let files = vec![content.join("pages").join("about.typ")];
+        let layout = SpineLayout::OnePerVertebra {
+            ext: "html".into(),
+            format: "html".into(),
+        };
+        let spine = VirtualSpine::build(SpineScan::flat(&files, &content), root, layout).unwrap();
+
+        assert_eq!(spine.vertebrae[0].handle, "pages:about");
+        assert_eq!(spine.vertebrae[0].output_path, "pages/about.html");
     }
 
     #[test]

--- a/crates/core/src/typ/rheo.typ
+++ b/crates/core/src/typ/rheo.typ
@@ -24,24 +24,9 @@
   }
 }
 
-// For #link(<handle>)[text] cross-vertebra links, strip the redundant fragment
-// (#handle) from the URL — the handle anchor is always at the top of the page,
-// so "llm.html" and "llm.html#llm" navigate to the same place. PDF is left
-// alone because all vertebrae share one file (internal anchors stay intact).
-#show link: it => context {
-  if type(it.dest) == label {
-    let matches = query(it.dest)
-    if matches.len() > 0 {
-      let elem = matches.first()
-      if elem.func() == figure and elem.kind == "rheo-handle" {
-        let fmt = target()
-        let ext = if fmt == "epub" { ".xhtml" } else if fmt == "html" { ".html" } else { none }
-        if ext != none {
-          let handle = repr(it.dest).slice(1, -1)
-          return link(handle + ext, it.body)
-        }
-      }
-    }
-  }
-  it
-}
+// The #show link rule that rewrites #link(<handle>)[text] cross-vertebra links
+// into per-format hrefs lives in the per-vertebra `rheo-context` prelude, not
+// here: it needs each file's own `rheo-context.handle` to compute a depth-
+// relative href (e.g. "../intro.html" from a nested page), and a show rule in
+// this shared main-file template captures only the main scope, never a
+// vertebra's local binding. See `VirtualSpine::rheo_context_preludes`.

--- a/crates/core/src/typ/rheo.typ
+++ b/crates/core/src/typ/rheo.typ
@@ -24,9 +24,32 @@
   }
 }
 
-// The #show link rule that rewrites #link(<handle>)[text] cross-vertebra links
-// into per-format hrefs lives in the per-vertebra `rheo-context` prelude, not
-// here: it needs each file's own `rheo-context.handle` to compute a depth-
-// relative href (e.g. "../intro.html" from a nested page), and a show rule in
-// this shared main-file template captures only the main scope, never a
-// vertebra's local binding. See `VirtualSpine::rheo_context_preludes`.
+// Rewrite #link(<handle>)[text] cross-vertebra links into per-format hrefs.
+// Only links whose target is a rheo-synthesized `rheo-handle` figure are
+// touched; authored labels pass through. The href is depth-relative to the
+// current page: the current page's handle is read from `state("rheo-handle")`
+// (published per-#document by the bundle source, since a show rule here in the
+// shared main-file template cannot see a vertebra's local `rheo-context`), and
+// the target handle's `:` separators become `/`, prefixed with one `../` per
+// level the current page is nested. The output extension comes from
+// `sys.inputs.rheo-context.ext`; when it is absent (PDF) the rule is a no-op and
+// native link handling applies. The redundant `#handle` fragment is dropped —
+// the anchor sits at the top of the target page.
+#show link: it => context {
+  let ext = sys.inputs.rheo-context.at("ext", default: none)
+  if ext == none { return it }
+  if type(it.dest) == label {
+    let matches = query(it.dest)
+    if matches.len() > 0 {
+      let elem = matches.first()
+      if elem.func() == figure and elem.kind == "rheo-handle" {
+        let target-handle = repr(it.dest).slice(1, -1)
+        let here-handle = state("rheo-handle").get()
+        let depth = here-handle.split(":").len() - 1
+        let prefix = if depth == 0 { "./" } else { range(depth).map(x => "../").join() }
+        return link(prefix + target-handle.replace(":", "/") + "." + ext, it.body)
+      }
+    }
+  }
+  it
+}

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -8,4 +8,5 @@ pub mod html;
 pub mod path;
 pub mod pdf;
 pub mod typst_literal;
+pub mod typst_source;
 pub mod typst_types;

--- a/crates/core/src/util/typst_source.rs
+++ b/crates/core/src/util/typst_source.rs
@@ -28,6 +28,15 @@ pub enum TypstStmt {
     Raw(String),
     /// `#let <name> = <value>`.
     Let { name: String, value: TypstLiteral },
+    /// The per-vertebra `rheo-context` binding, as a zero-arg function that
+    /// composes this file's `handle` with the format-global values spread from
+    /// `sys.inputs.rheo-context`:
+    /// `#let rheo-context() = (handle: "<handle>", ..sys.inputs.rheo-context)`.
+    /// The function form lets authors mock it under vanilla Typst; the spread
+    /// keeps the (potentially large) `spine` stored once in `sys.inputs` rather
+    /// than baked into every vertebra. `sys.inputs` reads need no `#context`, so
+    /// authors still read `rheo-context().handle` directly.
+    ContextBinding { handle: String },
     /// `#state("<key>").update(<value>)`.
     StateUpdate { key: String, value: TypstLiteral },
     /// A cross-vertebra handle anchor: a labeled, hidden `rheo-handle` `#figure`
@@ -52,6 +61,11 @@ impl fmt::Display for TypstStmt {
             TypstStmt::Let { name, value } => {
                 write!(f, "#let {} = {}", name, value.serialize())
             }
+            TypstStmt::ContextBinding { handle } => write!(
+                f,
+                "#let rheo-context() = (handle: {}, ..sys.inputs.rheo-context)",
+                TypstLiteral::str(handle.as_str()).serialize()
+            ),
             TypstStmt::StateUpdate { key, value } => write!(
                 f,
                 "#state({}).update({})",
@@ -98,6 +112,17 @@ mod tests {
             value: TypstLiteral::Dict(vec![("handle".into(), TypstLiteral::str("intro"))]),
         };
         assert_eq!(stmt.to_string(), "#let rheo-context = (handle: \"intro\")");
+    }
+
+    #[test]
+    fn context_binding_composes_handle_with_sys_inputs() {
+        let stmt = TypstStmt::ContextBinding {
+            handle: "chapters:ch1".into(),
+        };
+        assert_eq!(
+            stmt.to_string(),
+            "#let rheo-context() = (handle: \"chapters:ch1\", ..sys.inputs.rheo-context)"
+        );
     }
 
     #[test]

--- a/crates/core/src/util/typst_source.rs
+++ b/crates/core/src/util/typst_source.rs
@@ -1,0 +1,150 @@
+//! A minimal Typst *statement* model for the source rheo synthesizes.
+//!
+//! Where [`TypstLiteral`](super::typst_literal::TypstLiteral) models a Typst
+//! *value*, [`TypstStmt`] models a top-level *statement* rheo injects into the
+//! compiled bundle — a `#let` prelude, a per-page `state().update()`, a
+//! `#document(..)[..]` wrapper, a cross-vertebra handle anchor, an `#include`.
+//! Assembling the synthesized source from these typed statements keeps the
+//! Typst syntax and escaping in one place instead of hand-written, separately
+//! escaped strings at each injection site.
+//!
+//! Opaque source rheo does not construct field-by-field — the `rheo.typ`
+//! template, the `target()` polyfill, a vertebra's own authored text — is not
+//! modeled here; it rides as [`TypstStmt::Raw`] when it needs to sit in a
+//! statement list.
+
+use crate::util::path::escape_typst_content;
+use crate::util::typst_literal::TypstLiteral;
+use std::fmt;
+
+/// A synthesized top-level Typst statement, rendered via [`fmt::Display`].
+///
+/// `Display` emits the bare statement — no surrounding indentation or trailing
+/// newline — so callers control layout. [`TypstStmt::Document`] is the one
+/// exception: it renders its own multi-line block (header, indented body,
+/// closing `]`).
+pub enum TypstStmt {
+    /// Verbatim Typst source (template blobs, polyfills, `#show: …` application).
+    Raw(String),
+    /// `#let <name> = <value>`.
+    Let { name: String, value: TypstLiteral },
+    /// `#state("<key>").update(<value>)`.
+    StateUpdate { key: String, value: TypstLiteral },
+    /// A cross-vertebra handle anchor: a labeled, hidden `rheo-handle` `#figure`
+    /// so `@label` / `#link(<label>)` resolve across the bundle.
+    HandleAnchor { label: String, title: String },
+    /// `#include "<path>"`.
+    Include { path: String },
+    /// A `#document("<output_path>", format: "<format>", title: [<title>])[ … ]`
+    /// block wrapping a body of statements, each rendered indented.
+    Document {
+        output_path: String,
+        format: String,
+        title: String,
+        body: Vec<TypstStmt>,
+    },
+}
+
+impl fmt::Display for TypstStmt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TypstStmt::Raw(s) => f.write_str(s),
+            TypstStmt::Let { name, value } => {
+                write!(f, "#let {} = {}", name, value.serialize())
+            }
+            TypstStmt::StateUpdate { key, value } => write!(
+                f,
+                "#state({}).update({})",
+                TypstLiteral::str(key.as_str()).serialize(),
+                value.serialize()
+            ),
+            TypstStmt::HandleAnchor { label, title } => write!(
+                f,
+                "#figure([{}], kind: \"rheo-handle\", supplement: none) <{}>",
+                escape_typst_content(title),
+                label
+            ),
+            TypstStmt::Include { path } => write!(f, "#include \"{}\"", path),
+            TypstStmt::Document {
+                output_path,
+                format,
+                title,
+                body,
+            } => {
+                writeln!(
+                    f,
+                    "#document(\"{}\", format: \"{}\", title: [{}])[",
+                    output_path,
+                    format,
+                    escape_typst_content(title)
+                )?;
+                for stmt in body {
+                    writeln!(f, "  {stmt}")?;
+                }
+                write!(f, "]")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn let_renders_binding_with_serialized_value() {
+        let stmt = TypstStmt::Let {
+            name: "rheo-context".into(),
+            value: TypstLiteral::Dict(vec![("handle".into(), TypstLiteral::str("intro"))]),
+        };
+        assert_eq!(stmt.to_string(), "#let rheo-context = (handle: \"intro\")");
+    }
+
+    #[test]
+    fn state_update_quotes_key_and_value() {
+        let stmt = TypstStmt::StateUpdate {
+            key: "rheo-handle".into(),
+            value: TypstLiteral::str("chapters:ch1"),
+        };
+        assert_eq!(
+            stmt.to_string(),
+            "#state(\"rheo-handle\").update(\"chapters:ch1\")"
+        );
+    }
+
+    #[test]
+    fn handle_anchor_escapes_title() {
+        let stmt = TypstStmt::HandleAnchor {
+            label: "intro".into(),
+            title: "Intro".into(),
+        };
+        assert_eq!(
+            stmt.to_string(),
+            "#figure([Intro], kind: \"rheo-handle\", supplement: none) <intro>"
+        );
+    }
+
+    #[test]
+    fn document_wraps_indented_body() {
+        let doc = TypstStmt::Document {
+            output_path: "chapters/ch1.html".into(),
+            format: "html".into(),
+            title: "Chapter 1".into(),
+            body: vec![
+                TypstStmt::StateUpdate {
+                    key: "rheo-handle".into(),
+                    value: TypstLiteral::str("chapters:ch1"),
+                },
+                TypstStmt::Include {
+                    path: "content/chapters/ch1.typ".into(),
+                },
+            ],
+        };
+        assert_eq!(
+            doc.to_string(),
+            "#document(\"chapters/ch1.html\", format: \"html\", title: [Chapter 1])[\n  \
+             #state(\"rheo-handle\").update(\"chapters:ch1\")\n  \
+             #include \"content/chapters/ch1.typ\"\n]"
+        );
+    }
+}

--- a/crates/core/src/world.rs
+++ b/crates/core/src/world.rs
@@ -560,7 +560,7 @@ mod tests {
         let mut rheo_context = HashMap::new();
         rheo_context.insert(
             "content/intro.typ".to_string(),
-            "#let rheo-context = (handle: \"intro\", spine: ())\n\n".to_string(),
+            "#let rheo-context() = (handle: \"intro\", ..sys.inputs.rheo-context)\n\n".to_string(),
         );
         let world = RheoWorld::new_for_bundle(
             root,
@@ -580,7 +580,7 @@ mod tests {
         .intern();
         let text = World::source(&world, id).unwrap().text().to_string();
         // The prelude is prepended ahead of the file's own body.
-        assert!(text.contains("#let rheo-context = (handle: \"intro\""));
+        assert!(text.contains("#let rheo-context() = (handle: \"intro\""));
         assert!(text.find("rheo-context").unwrap() < text.find("= Intro").unwrap());
     }
 

--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -153,6 +153,11 @@ impl FormatPlugin for HtmlPlugin {
 
             let out_path = ctx.output_dir.join(&output.output_path);
             debug!(size = html_string.len(), "writing HTML file");
+            if let Some(parent) = out_path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    RheoError::io(e, format!("creating output directory {:?}", parent))
+                })?;
+            }
             std::fs::write(&out_path, &html_string)
                 .map_err(|e| RheoError::io(e, format!("writing HTML file to {:?}", out_path)))?;
             info!(output = %out_path.display(), "successfully compiled to HTML");

--- a/crates/html/src/server.rs
+++ b/crates/html/src/server.rs
@@ -309,19 +309,25 @@ fn directory_listing(html_dir: &Path, path: &str) -> Response {
         Err(_) => return (StatusCode::NOT_FOUND, "Directory not found").into_response(),
     };
 
-    let mut html_files: Vec<String> = entries
+    // List HTML files plus subdirectories: nested vertebrae land in real
+    // subdirectories (e.g. `chapters/ch1.html`), so a subdir gets a trailing-
+    // slash entry the user drills into rather than a flat colon filename.
+    let mut names: Vec<String> = entries
         .filter_map(|entry| {
             let entry = entry.ok()?;
-            let path = entry.path();
-            if path.extension()? == "html" {
-                Some(path.file_name()?.to_string_lossy().to_string())
+            let entry_path = entry.path();
+            let file_name = entry_path.file_name()?.to_string_lossy().to_string();
+            if entry_path.is_dir() {
+                Some(format!("{file_name}/"))
+            } else if entry_path.extension().is_some_and(|e| e == "html") {
+                Some(file_name)
             } else {
                 None
             }
         })
         .collect();
 
-    html_files.sort();
+    names.sort();
 
     let mut html = String::from(
         r#"<!DOCTYPE html>
@@ -344,17 +350,16 @@ fn directory_listing(html_dir: &Path, path: &str) -> Response {
 "#,
     );
 
-    if html_files.is_empty() {
+    if names.is_empty() {
         html.push_str("<li>No HTML files found</li>");
     } else {
-        for file in html_files {
-            // Prefix the href with `./` so a colon in a nested vertebra's
-            // filename (e.g. `chapters:intro.html`) isn't parsed as a URL
-            // scheme by the browser, which would break the link.
+        for name in names {
+            // Prefix each href with `./` so it resolves relative to the current
+            // directory regardless of how the listing URL is written.
             html.push_str(&format!(
                 r#"        <li><a href="./{}">{}</a></li>
 "#,
-                file, file
+                name, name
             ));
         }
     }
@@ -419,13 +424,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_directory_listing_prefixes_href_for_colon_filenames() {
-        // Nested vertebrae land on disk as flat, colon-separated filenames
-        // (e.g. `chapters:intro.html`). The listing must not emit a bare
-        // `href="chapters:intro.html"` — the browser would read `chapters:`
-        // as a URL scheme and break the link. A `./` prefix fixes it.
+    async fn test_directory_listing_lists_files_and_subdirs() {
+        // Nested vertebrae land in real subdirectories (e.g. `chapters/ch1.html`).
+        // The root listing shows top-level HTML files plus a trailing-slash entry
+        // per subdirectory to drill into; every href is `./`-prefixed so it
+        // resolves relative to the current directory.
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("chapters:intro.html"), "<html></html>").unwrap();
+        std::fs::write(dir.path().join("intro.html"), "<html></html>").unwrap();
+        std::fs::create_dir(dir.path().join("chapters")).unwrap();
+        std::fs::write(
+            dir.path().join("chapters").join("ch1.html"),
+            "<html></html>",
+        )
+        .unwrap();
 
         let response = directory_listing(dir.path(), "");
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -434,12 +445,12 @@ mod tests {
         let html = String::from_utf8(body.to_vec()).unwrap();
 
         assert!(
-            html.contains(r#"href="./chapters:intro.html""#),
-            "expected a `./`-prefixed href, got: {html}"
+            html.contains(r#"href="./intro.html""#),
+            "expected the root HTML file, got: {html}"
         );
         assert!(
-            !html.contains(r#"href="chapters:intro.html""#),
-            "bare colon href would be parsed as a URL scheme: {html}"
+            html.contains(r#"href="./chapters/""#),
+            "expected a drill-in link for the subdirectory, got: {html}"
         );
     }
 }


### PR DESCRIPTION
Also fixes #154.