### PR TITLE
Reset footnotes in HTML by default

### DIFF
--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -222,6 +222,13 @@ impl Build {
         let target = plugin.rheo_target();
         let ext = target.map(|_| plugin.extension());
         let rheo_context = virtual_spine.rheo_context_preludes();
+        // Per-format footnote-reset toggle (default true); only takes effect for
+        // per-page formats, since rheo.typ ANDs it with the `ext` gate.
+        let reset_footnotes = self
+            .project
+            .config
+            .plugin_section(plugin.name())
+            .reset_footnotes();
 
         // Single Typst bundle compile for this plugin.
         let world = RheoWorld::new_for_bundle(
@@ -229,7 +236,7 @@ impl Build {
             moulded.main,
             moulded.sources,
             rheo_context,
-            Some(virtual_spine.global_context(target, ext)),
+            Some(virtual_spine.global_context(target, ext, reset_footnotes)),
             plugin.rheo_target(),
             self.font_dirs.clone(),
         )?;

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -130,6 +130,14 @@ pub struct PluginSection {
     #[serde(default)]
     pub auto_detect_packages: Option<bool>,
 
+    /// When true (default), per-page output for this format resets the footnote
+    /// counter to 1 on every page; false lets footnotes accumulate across the
+    /// bundle. Only meaningful for the per-page formats (HTML/EPUB); PDF combines
+    /// into a single document with no `ext`, so the reset gate in `typ/rheo.typ`
+    /// never fires there regardless. Read via [`PluginSection::reset_footnotes`].
+    #[serde(default)]
+    pub reset_footnotes: Option<bool>,
+
     /// Plugin-specific extra fields from the TOML section (e.g. `stylesheets`,
     /// `fonts` for HTML; `identifier`, `date` for EPUB).
     #[serde(flatten, default)]
@@ -332,6 +340,12 @@ impl PluginSection {
         self.auto_detect_packages.unwrap_or(true)
     }
 
+    /// Per-page footnote-counter reset (HTML/EPUB) defaults to true; users can
+    /// disable per-format with `reset_footnotes = false`.
+    pub fn reset_footnotes(&self) -> bool {
+        self.reset_footnotes.unwrap_or(true)
+    }
+
     /// Deserialize the format-specific `extra` fields into a typed config struct.
     ///
     /// Plugins define a `#[derive(Deserialize, Default)]` struct for their own
@@ -411,6 +425,25 @@ mod tests {
         let toml = versioned_toml(r#"formats = ["pdf"]"#);
         let config = parse(&toml);
         assert_eq!(config.formats, vec!["pdf"]);
+    }
+
+    #[test]
+    fn test_reset_footnotes_defaults_true_and_honors_false_per_format() {
+        // No [html] section at all -> default section, defaults to true.
+        let config = parse(&versioned_toml(r#"formats = ["html"]"#));
+        assert!(config.plugin_section("html").reset_footnotes());
+
+        // Explicit false on [html] is honored, and is per-format: [epub] still
+        // defaults to true.
+        let config = parse(&versioned_toml(
+            "[html]\nreset_footnotes = false\n[epub]\n",
+        ));
+        assert!(!config.plugin_section("html").reset_footnotes());
+        assert!(config.plugin_section("epub").reset_footnotes());
+
+        // Explicit true.
+        let config = parse(&versioned_toml("[html]\nreset_footnotes = true\n"));
+        assert!(config.plugin_section("html").reset_footnotes());
     }
 
     #[test]

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -435,9 +435,7 @@ mod tests {
 
         // Explicit false on [html] is honored, and is per-format: [epub] still
         // defaults to true.
-        let config = parse(&versioned_toml(
-            "[html]\nreset_footnotes = false\n[epub]\n",
-        ));
+        let config = parse(&versioned_toml("[html]\nreset_footnotes = false\n[epub]\n"));
         assert!(!config.plugin_section("html").reset_footnotes());
         assert!(config.plugin_section("epub").reset_footnotes());
 

--- a/crates/core/src/reticulate/bundle_source.rs
+++ b/crates/core/src/reticulate/bundle_source.rs
@@ -1,11 +1,5 @@
-use crate::util::typst_literal::TypstLiteral;
 use crate::util::typst_source::TypstStmt;
 use std::fmt;
-
-/// Typst `state` key carrying the current page's handle, published per-document
-/// so `typ/rheo.typ`'s cross-vertebra link rule can read it (see the rule and
-/// [`BundleDocument::to_stmt`]).
-const HANDLE_STATE_KEY: &str = "rheo-handle";
 
 /// A handle anchor emitted into a `BundleDocument` body so that `@label` cross-references
 /// resolve across vertebrae during bundle compilation.
@@ -56,13 +50,13 @@ impl fmt::Display for BundleSource {
 }
 
 impl BundleDocument {
-    /// Render this document as a [`TypstStmt::Document`]: a per-page handle
-    /// `state` update, then each segment's handle anchors followed by its
-    /// `#include`, in order.
+    /// Render this document as a [`TypstStmt::Document`]: a per-page init hook
+    /// (`#rheo-page-init`, which publishes the handle to `state` and resets the
+    /// footnote counter for per-page output), then each segment's handle anchors
+    /// followed by its `#include`, in order.
     fn to_stmt(&self) -> TypstStmt {
-        let mut body = vec![TypstStmt::StateUpdate {
-            key: HANDLE_STATE_KEY.to_string(),
-            value: TypstLiteral::str(self.handle.as_str()),
+        let mut body = vec![TypstStmt::PageInit {
+            handle: self.handle.clone(),
         }];
         for segment in &self.segments {
             for anchor in &segment.anchors {

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -831,7 +831,17 @@ impl VirtualSpine {
     /// each field is added when `Some`, omitted for PDF (`None`). `ext` is the
     /// output file extension (e.g. `"html"`/`"xhtml"`) — the value `typ/rheo.typ`
     /// reads to build cross-vertebra link hrefs.
-    pub fn global_context(&self, target: Option<&str>, ext: Option<&str>) -> TypstLiteral {
+    ///
+    /// `reset_footnotes` is the resolved per-format `reset-footnotes` toggle:
+    /// unlike `target`/`ext` it is always present (a resolved bool, not an
+    /// `Option`), and `typ/rheo.typ` ANDs it with the per-page `ext` gate before
+    /// resetting the footnote counter (so it only ever takes effect for HTML/EPUB).
+    pub fn global_context(
+        &self,
+        target: Option<&str>,
+        ext: Option<&str>,
+        reset_footnotes: bool,
+    ) -> TypstLiteral {
         let mut fields = vec![
             ("spine".to_string(), self.spine_tree()),
             ("spine-flat".to_string(), self.spine_flat()),
@@ -842,6 +852,10 @@ impl VirtualSpine {
         if let Some(e) = ext {
             fields.push(("ext".to_string(), TypstLiteral::str(e)));
         }
+        fields.push((
+            "reset-footnotes".to_string(),
+            TypstLiteral::bool(reset_footnotes),
+        ));
         TypstLiteral::Dict(fields)
     }
 
@@ -1191,21 +1205,27 @@ mod tests {
 
         // target/ext live on the global context (sys.inputs); the per-file
         // prelude only spreads them in, so they are asserted on global_context.
-        let global_html = spine.global_context(Some("html"), Some("html")).serialize();
+        let global_html = spine
+            .global_context(Some("html"), Some("html"), true)
+            .serialize();
         assert!(global_html.contains("target: \"html\""));
         assert!(global_html.contains("ext: \"html\""));
+        // The resolved reset-footnotes toggle is always present (unlike target/ext).
+        assert!(global_html.contains("reset-footnotes: true"));
 
-        // Epub keeps `target` "epub" but `ext` "xhtml".
+        // Epub keeps `target` "epub" but `ext` "xhtml"; a false toggle is threaded through.
         let global_epub = spine
-            .global_context(Some("epub"), Some("xhtml"))
+            .global_context(Some("epub"), Some("xhtml"), false)
             .serialize();
         assert!(global_epub.contains("target: \"epub\""));
         assert!(global_epub.contains("ext: \"xhtml\""));
+        assert!(global_epub.contains("reset-footnotes: false"));
 
-        // None (PDF) -> no `target` or `ext` field.
-        let global_without = spine.global_context(None, None).serialize();
+        // None (PDF) -> no `target` or `ext` field, but reset-footnotes is still present.
+        let global_without = spine.global_context(None, None, true).serialize();
         assert!(!global_without.contains("target:"));
         assert!(!global_without.contains("ext:"));
+        assert!(global_without.contains("reset-footnotes: true"));
     }
 
     #[test]

--- a/crates/core/src/reticulate/spine.rs
+++ b/crates/core/src/reticulate/spine.rs
@@ -1264,6 +1264,8 @@ mod tests {
         };
         let src = spine.source();
         assert!(src.contains("#document(\"intro.html\", format: \"html\""));
+        // Per-document init hook: publishes the handle and (per-page) resets footnotes.
+        assert!(src.contains("#rheo-page-init(\"intro\")"));
         assert!(src.contains("rheo-handle"));
         assert!(src.contains("[Introduction]"));
         assert!(src.contains("<intro>"));
@@ -1307,6 +1309,9 @@ mod tests {
         };
         let src = spine.source();
         assert!(src.contains("#document(\"doc.pdf\", format: \"pdf\""));
+        // Combined PDF is one document with an empty handle; the hook still runs
+        // (no `ext` at compile time -> the footnote reset inside it is skipped).
+        assert!(src.contains("#rheo-page-init(\"\")"));
         assert!(src.contains("#include \"content/a.typ\""));
         assert!(src.contains("#include \"content/b.typ\""));
         // Synthesized handle anchors are now injected into the combined document so

--- a/crates/core/src/typ/rheo.typ
+++ b/crates/core/src/typ/rheo.typ
@@ -58,11 +58,14 @@
 // bundle source (crates/core/src/reticulate/bundle_source.rs). Publishes this
 // page's handle to state("rheo-handle") for the cross-vertebra link rule above,
 // and — for per-page output (html/epub, where rheo-context carries an `ext`) —
-// resets the footnote counter so each page numbers its footnotes from 1. The
-// combined PDF has no `ext`, so its footnotes stay continuous across the book.
+// resets the footnote counter so each page numbers its footnotes from 1 —
+// unless the format's `reset_footnotes` toggle is set false. The combined PDF
+// has no `ext`, so its footnotes stay continuous across the book regardless.
 #let rheo-page-init(handle) = {
   state("rheo-handle").update(handle)
-  if sys.inputs.rheo-context.at("ext", default: none) != none {
+  let per-page = sys.inputs.rheo-context.at("ext", default: none) != none
+  let reset = sys.inputs.rheo-context.at("reset-footnotes", default: true)
+  if per-page and reset {
     counter(footnote).update(0)
   }
 }

--- a/crates/core/src/typ/rheo.typ
+++ b/crates/core/src/typ/rheo.typ
@@ -44,6 +44,12 @@
       let elem = matches.first()
       if elem.func() == figure and elem.kind == "rheo-handle" {
         let target-handle = repr(it.dest).slice(1, -1)
+        // The `<handle.typ>` escape alias resolves to the same vertebra output
+        // as the canonical `<handle>`, so drop a trailing `.typ` before building
+        // the href — otherwise it would point at a nonexistent `…/x.typ.html`.
+        if target-handle.ends-with(".typ") {
+          target-handle = target-handle.slice(0, -4)
+        }
         let here-handle = state("rheo-handle").get()
         let depth = here-handle.split(":").len() - 1
         let prefix = if depth == 0 { "./" } else { range(depth).map(x => "../").join() }

--- a/crates/core/src/typ/rheo.typ
+++ b/crates/core/src/typ/rheo.typ
@@ -53,3 +53,16 @@
   }
   it
 }
+
+// Per-document init hook, called once at the top of each #document block by the
+// bundle source (crates/core/src/reticulate/bundle_source.rs). Publishes this
+// page's handle to state("rheo-handle") for the cross-vertebra link rule above,
+// and — for per-page output (html/epub, where rheo-context carries an `ext`) —
+// resets the footnote counter so each page numbers its footnotes from 1. The
+// combined PDF has no `ext`, so its footnotes stay continuous across the book.
+#let rheo-page-init(handle) = {
+  state("rheo-handle").update(handle)
+  if sys.inputs.rheo-context.at("ext", default: none) != none {
+    counter(footnote).update(0)
+  }
+}

--- a/crates/core/src/util/typst_literal.rs
+++ b/crates/core/src/util/typst_literal.rs
@@ -13,6 +13,8 @@
 pub enum TypstLiteral {
     /// A string literal (escaped on serialize).
     Str(String),
+    /// A boolean literal (`true`/`false`).
+    Bool(bool),
     /// The `none` literal.
     None,
     /// An array literal, e.g. `(a, b,)`.
@@ -27,6 +29,11 @@ impl TypstLiteral {
         TypstLiteral::Str(s.into())
     }
 
+    /// A boolean value.
+    pub fn bool(b: bool) -> Self {
+        TypstLiteral::Bool(b)
+    }
+
     /// Serialize to a Typst literal.
     ///
     /// Empty array serializes to `()`, empty dictionary to `(:)`. String values
@@ -35,6 +42,7 @@ impl TypstLiteral {
     pub fn serialize(&self) -> String {
         match self {
             TypstLiteral::Str(s) => serialize_string(s),
+            TypstLiteral::Bool(b) => b.to_string(),
             TypstLiteral::None => "none".to_string(),
             TypstLiteral::Array(items) if items.is_empty() => "()".to_string(),
             TypstLiteral::Array(items) => {
@@ -58,6 +66,7 @@ impl TypstLiteral {
         use typst::foundations::{Array, Dict, Value};
         match self {
             TypstLiteral::Str(s) => Value::Str(s.as_str().into()),
+            TypstLiteral::Bool(b) => Value::Bool(*b),
             TypstLiteral::None => Value::None,
             TypstLiteral::Array(items) => {
                 Value::Array(items.iter().map(TypstLiteral::to_value).collect::<Array>())
@@ -108,6 +117,14 @@ mod tests {
     fn empty_array_and_dict_use_typst_syntax() {
         assert_eq!(TypstLiteral::Array(vec![]).serialize(), "()");
         assert_eq!(TypstLiteral::Dict(vec![]).serialize(), "(:)");
+    }
+
+    #[test]
+    fn bool_serializes_and_converts_to_value_bool() {
+        use typst::foundations::Value;
+        assert_eq!(TypstLiteral::bool(true).serialize(), "true");
+        assert_eq!(TypstLiteral::bool(false).serialize(), "false");
+        assert_eq!(TypstLiteral::bool(true).to_value(), Value::Bool(true));
     }
 
     #[test]

--- a/crates/core/src/util/typst_source.rs
+++ b/crates/core/src/util/typst_source.rs
@@ -39,6 +39,11 @@ pub enum TypstStmt {
     ContextBinding { handle: String },
     /// `#state("<key>").update(<value>)`.
     StateUpdate { key: String, value: TypstLiteral },
+    /// `#rheo-page-init("<handle>")` — the per-document init hook defined in
+    /// `typ/rheo.typ`: it publishes the page handle to `state` and, for per-page
+    /// (html/epub) output, resets the footnote counter so each page numbers its
+    /// footnotes from 1.
+    PageInit { handle: String },
     /// A cross-vertebra handle anchor: a labeled, hidden `rheo-handle` `#figure`
     /// so `@label` / `#link(<label>)` resolve across the bundle.
     HandleAnchor { label: String, title: String },
@@ -71,6 +76,11 @@ impl fmt::Display for TypstStmt {
                 "#state({}).update({})",
                 TypstLiteral::str(key.as_str()).serialize(),
                 value.serialize()
+            ),
+            TypstStmt::PageInit { handle } => write!(
+                f,
+                "#rheo-page-init({})",
+                TypstLiteral::str(handle.as_str()).serialize()
             ),
             TypstStmt::HandleAnchor { label, title } => write!(
                 f,
@@ -135,6 +145,14 @@ mod tests {
             stmt.to_string(),
             "#state(\"rheo-handle\").update(\"chapters:ch1\")"
         );
+    }
+
+    #[test]
+    fn page_init_quotes_handle() {
+        let stmt = TypstStmt::PageInit {
+            handle: "chapters:ch1".into(),
+        };
+        assert_eq!(stmt.to_string(), "#rheo-page-init(\"chapters:ch1\")");
     }
 
     #[test]


### PR DESCRIPTION
Because Rheo constructs a virtual bundle under the hood, footnotes currently don't reset per page. As I am using Rheo primarily for blogging and documentation at the moment, resetting footnotes per page as a default seems sensible. We also expose a knob in rheo.toml under the `reset_footnotes` attribute, in case the user wants it the other way around. 