### PR TITLE
v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "rheo"
-version = "0.6.0"
+version = "0.5.2"
 dependencies = [
  "atty",
  "axum",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "rheo-core"
-version = "0.6.0"
+version = "0.5.2"
 dependencies = [
  "atty",
  "chrono",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "rheo-epub"
-version = "0.6.0"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "iref",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "rheo-html"
-version = "0.6.0"
+version = "0.5.2"
 dependencies = [
  "atom_syndication",
  "axum",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "rheo-pdf"
-version = "0.6.0"
+version = "0.5.2"
 dependencies = [
  "rheo-core",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/html", "crates/pdf", "crates/epub", "crates/cli"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.5.2"
 edition = "2024"
 authors = ["Lachlan Kermode <lachie@ohrg.org>"]
 description = "A typesetting and static site engine based on Typst"
@@ -13,10 +13,10 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal crates (for convenience in workspace)
-rheo-core = { path = "crates/core", version = "0.6.0" }
-rheo-html = { path = "crates/html", version = "0.6.0" }
-rheo-pdf = { path = "crates/pdf", version = "0.6.0" }
-rheo-epub = { path = "crates/epub", version = "0.6.0" }
+rheo-core = { path = "crates/core", version = "0.5.2" }
+rheo-html = { path = "crates/html", version = "0.5.2" }
+rheo-pdf = { path = "crates/pdf", version = "0.5.2" }
+rheo-epub = { path = "crates/epub", version = "0.5.2" }
 
 # Typst dependencies
 typst = "0.15.0"


### PR DESCRIPTION
- Bumps workspace version to 0.5.2
  - Releases marrow (#164) as a patch on the 0.5 line