### PR TITLE
Allow local custom namespaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,12 +90,16 @@ releases = "freecomputinglab/rookery"  # <owner>/<repo>, or a URL template
 repo = "https://github.com/freecomputinglab/rheo-packages"  # any URL git accepts
 branch = "feat-x"                      # or tag = "...", or rev = "<sha>"
 subdir = ""                            # optional path prefix inside the repo
+
+[packages.demo]                        # resolves from a directory on disk
+path = "../pkgs"                       # a package's own working tree, read in place
 ```
 
-**`[packages.<namespace>]`** declares where one namespace comes from. Set exactly one of `repo` or `releases` — switching a project between a release and a branch is an explicit edit, not a precedence rule.
+**`[packages.<namespace>]`** declares where one namespace comes from. Set exactly one of `repo`, `releases` or `path` — switching a project between a release, a branch and a local directory is an explicit edit, not a precedence rule.
 
 - `releases` takes an `<owner>/<repo>` shorthand (detected by having no scheme), expanded to GitHub's download base, or a full URL template containing both `{name}` and `{version}` for any other forge. Assets are `<name>-<version>.tar.gz` under the tag `<name>-<version>`.
 - `repo` takes any URL the `git` binary accepts — https, ssh, or a local path. `branch` (default `main`), `tag` and `rev` select the ref; when more than one is set the precedence is `rev`, then `tag`, then `branch`, and the losing keys are warned about rather than silently dropped. `subdir` (default empty) is a path prefix inside the repository, so `@<ns>/<name>:<version>` lives at `<subdir>/<name>/<version>/`.
+- `path` points straight at a directory holding `<name>/<version>/` package trees — no git, no clone, no cache, so an edit to the package shows up on the very next build. A relative `path` resolves against `rheo.toml`'s own directory. There is no `branch`/`tag`/`rev` alongside it (there is no ref to select); `subdir` still applies. **This is machine-local** — it is a line you flip on your own checkout, not something a teammate's build can see, and rheo has no local-override config file to keep it out of a committed `rheo.toml`.
 
 The namespace key must be a Typst identifier, since it appears in every import spec as `@<namespace>/name:1.0.0`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,12 @@ your own disk, not something committed for anyone else to build against.
 rheo has no local-override config file (yet) to keep a `path` entry out of a
 shared `rheo.toml` — flip it locally, and flip it back before committing.
 
+`rheo watch` picks this up too: a `path`-backed package's directory is watched
+the same as the project itself, so editing a `.typ` file inside it rebuilds
+the consuming site within the usual debounce window — even when the package
+declares no `[tool.rheo.*]` assets of its own, which is the common case for a
+package that is pure Typst with no stylesheet or script.
+
 # 0.6.2 — user-visible changes
 
 ## A package served from a repository ref contributes its marrow again

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,25 @@
+# Unreleased — user-visible changes
+
+## A package namespace can resolve straight from a directory on disk
+
+`[packages.<ns>]` gained a third source alongside `repo` and `releases`: `path
+= "../pkgs"` points a namespace at a directory holding `<name>/<version>/`
+package trees, read in place. There is no git operation and no cache — the
+directory the Typst compile reads IS the working tree, so an edit to the
+package shows up on the very next build rather than needing a commit and a
+bookmark move first.
+
+This is for the loop of editing a package and the site that consumes it
+together. Before, that loop went through `repo = "<local checkout>"`, which
+works but still clones a fresh tree into `~/.cache/rheo/git/` for every commit
+along the way. `path` skips all of that.
+
+It is deliberately machine-local: a relative `path` resolves against
+`rheo.toml`'s own directory, but the directory it names is still a line on
+your own disk, not something committed for anyone else to build against.
+rheo has no local-override config file (yet) to keep a `path` entry out of a
+shared `rheo.toml` — flip it locally, and flip it back before committing.
+
 # 0.6.2 — user-visible changes
 
 ## A package served from a repository ref contributes its marrow again

--- a/crates/core/src/build.rs
+++ b/crates/core/src/build.rs
@@ -199,18 +199,27 @@ impl Build {
     /// plugins actually declare rather than a hard-coded extension list.
     ///
     /// Only packages that declare rheo assets in their `typst.toml` contribute a
-    /// source root here, so the watched set stays tight (immutable `@preview`
-    /// deps that declare nothing are never watched).
+    /// source root here through the per-plugin pass below, so the watched set
+    /// stays tight (immutable `@preview` deps that declare nothing are never
+    /// watched) — EXCEPT a `path`-backed package, added unconditionally just
+    /// after: unlike a repository ref or a release, both immutable caches, its
+    /// tree can change while the watch is running, so it must be covered
+    /// whether or not it ships an asset block.
     pub fn watch_asset_spec(&self) -> crate::assets::watch::WatchAssetSpec {
         let default_section = PluginSection::default();
+        let resolver = self.package_resolver();
         let packages = PackageIndex::resolved(
             &crate::plugins::scan_project_package_imports(&self.project.typ_files),
-            &self.package_resolver(),
+            &resolver,
         );
 
         let mut asset_paths: Vec<PathBuf> = Vec::new();
         let mut copy_globs: Vec<(PathBuf, Vec<String>)> = Vec::new();
-        let mut package_roots: Vec<PathBuf> = Vec::new();
+        let mut package_roots: Vec<PathBuf> = packages
+            .source_roots()
+            .filter(|(namespace, _)| resolver.is_path_backed(namespace))
+            .map(|(_, root)| root.to_path_buf())
+            .collect();
 
         for plugin in &self.plugins {
             // A resolve failure must not silently shrink the watched set: warn
@@ -1456,6 +1465,77 @@ mod tests {
         let head_end = html.find("</head>").expect("has head");
         let meta_pos = html.find("name=\"x\"").expect("meta present");
         assert!(meta_pos < head_end, "meta not hoisted into head:\n{html}");
+    }
+
+    /// A `path`-backed package with no `[tool.rheo.*]` assets at all still gets
+    /// its directory watched — unlike a repository ref or a release, its tree
+    /// can change while the watch is running, so watch coverage cannot be
+    /// gated on whether the package happens to declare an asset block.
+    #[test]
+    fn test_watch_asset_spec_watches_path_backed_package_without_assets() {
+        use crate::config::project::ProjectConfig;
+        use crate::config::{NamespaceSource, PathSource};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("content")).expect("create content dir");
+        std::fs::write(
+            root.join("content/index.typ"),
+            "#import \"@demo/thing:0.1.0\": greet\n#greet()\n",
+        )
+        .expect("write content/index.typ");
+
+        let pkg_dir = root.join("pkgs/thing/0.1.0");
+        std::fs::create_dir_all(pkg_dir.join("src")).expect("create package dir");
+        std::fs::write(
+            pkg_dir.join("typst.toml"),
+            "[package]\nname = \"thing\"\nversion = \"0.1.0\"\nentrypoint = \"src/lib.typ\"\n",
+        )
+        .expect("write typst.toml");
+        std::fs::write(pkg_dir.join("src/lib.typ"), "#let greet() = [Hi]\n")
+            .expect("write lib.typ");
+
+        let project = ProjectConfig {
+            name: "test".to_string(),
+            root: root.to_path_buf(),
+            config: crate::RheoConfig {
+                content_dir: Some("content".to_string()),
+                formats: vec!["html".to_string()],
+                packages: HashMap::from([(
+                    "demo".to_string(),
+                    NamespaceSource::Path(PathSource {
+                        root: root.join("pkgs"),
+                        subdir: String::new(),
+                    }),
+                )]),
+                ..Default::default()
+            },
+            typ_files: vec![root.join("content/index.typ")],
+            mode: ProjectMode::Directory,
+            config_path: None,
+        };
+
+        struct HtmlNoAssets;
+        impl FormatPlugin for HtmlNoAssets {
+            fn name(&self) -> &'static str {
+                "html"
+            }
+            fn compile(&self, _ctx: PluginContext<'_>, _outputs: &[CastVertebra]) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let plugin: Box<dyn FormatPlugin> = Box::new(HtmlNoAssets);
+        let build =
+            Build::prepare(project, vec![plugin], BuildOptions::default()).expect("prepare build");
+
+        let spec = build.watch_asset_spec();
+        let expected = pkg_dir.canonicalize().unwrap_or(pkg_dir);
+        assert!(
+            spec.package_roots().contains(&expected),
+            "expected {expected:?} in package_roots, got {:?}",
+            spec.package_roots()
+        );
     }
 
     /// Same as above, but with a CSS asset present, so the shared step's

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -12,7 +12,7 @@ pub mod retired;
 pub mod validation;
 
 pub use manifest_version::ManifestVersion;
-pub use packages::{GitRef, NamespaceSource, ReleasesSource, RepoSource};
+pub use packages::{GitRef, NamespaceSource, PathSource, ReleasesSource, RepoSource};
 pub use retired::{RETIRED_KEYS, RetiredKey};
 use validation::ValidateConfig;
 
@@ -379,7 +379,7 @@ impl RheoConfig {
         }
 
         debug!(path = %config_path.display(), "loading configuration");
-        Self::parse_config(&config_path, "rheo.toml")
+        Self::parse_config(&config_path, "rheo.toml", project_root)
     }
 
     /// Load configuration from a specific path with validation.
@@ -397,20 +397,33 @@ impl RheoConfig {
             ));
         }
 
-        let config = Self::parse_config(config_path, "config file")?;
+        let base_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
+        let config = Self::parse_config(config_path, "config file", base_dir)?;
         debug!(path = %config_path.display(), "loaded custom configuration");
         Ok(config)
     }
 
     /// Read, parse, convert, and validate a config file.
-    fn parse_config(config_path: &Path, label: &str) -> Result<Self> {
+    ///
+    /// `base_dir` is the directory a relative `[packages.<ns>] path` resolves
+    /// against — the config file's own directory, not the process's cwd, so
+    /// `path = "../rookery"` means the same thing however rheo was invoked.
+    fn parse_config(config_path: &Path, label: &str, base_dir: &Path) -> Result<Self> {
         let contents = std::fs::read_to_string(config_path)
             .map_err(|e| crate::RheoError::io(e, format!("reading {}", config_path.display())))?;
 
         let raw: RheoConfigRaw = toml::from_str(&contents)
             .map_err(|e| crate::RheoError::project_config(format!("invalid {}: {}", label, e)))?;
-        let config = RheoConfig::try_from(raw)
+        let mut config = RheoConfig::try_from(raw)
             .map_err(|e| crate::RheoError::project_config(format!("invalid {}: {}", label, e)))?;
+
+        for source in config.packages.values_mut() {
+            if let NamespaceSource::Path(path) = source
+                && path.root.is_relative()
+            {
+                path.root = base_dir.join(&path.root);
+            }
+        }
 
         config.validate()?;
         Ok(config)
@@ -1101,5 +1114,49 @@ mod tests {
         assert!(section.title.is_none());
         assert!(section.include.len() == 1);
         assert!(section.section.is_empty());
+    }
+
+    /// A relative `[packages.<ns>] path` resolves against the CONFIG FILE'S OWN
+    /// directory, not the process's cwd — so it means the same thing however
+    /// rheo was invoked.
+    #[test]
+    fn test_relative_package_path_resolves_against_config_dir() {
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("rheo.toml");
+        std::fs::write(
+            &config_path,
+            versioned_toml("[packages.ns]\npath = \"../pkgs\"\n"),
+        )
+        .unwrap();
+
+        let config = RheoConfig::load_from_path(&config_path).expect("load failed");
+        let NamespaceSource::Path(source) = config.packages.get("ns").expect("namespace absent")
+        else {
+            panic!("expected a path source");
+        };
+        assert_eq!(source.root, temp.path().join("../pkgs"));
+    }
+
+    /// An absolute `path` passes through unchanged.
+    #[test]
+    fn test_absolute_package_path_is_left_unchanged() {
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("rheo.toml");
+        std::fs::write(
+            &config_path,
+            versioned_toml("[packages.ns]\npath = \"/abs/pkgs\"\n"),
+        )
+        .unwrap();
+
+        let config = RheoConfig::load_from_path(&config_path).expect("load failed");
+        let NamespaceSource::Path(source) = config.packages.get("ns").expect("namespace absent")
+        else {
+            panic!("expected a path source");
+        };
+        assert_eq!(source.root, std::path::PathBuf::from("/abs/pkgs"));
     }
 }

--- a/crates/core/src/config/packages.rs
+++ b/crates/core/src/config/packages.rs
@@ -2,12 +2,13 @@
 //!
 //! Without this table `@rheo` resolves from its built-in releases host and every
 //! other namespace goes to Typst universe. A table entry replaces that for one
-//! namespace, either with a repository checked out at a ref or with a different
-//! releases host.
+//! namespace: a repository checked out at a ref, a different releases host, or
+//! a directory on disk.
 
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::path::PathBuf;
 use tracing::warn;
 
 /// The GitHub download base a bare `<owner>/<repo>` shorthand expands to.
@@ -98,6 +99,16 @@ impl ReleasesSource {
     }
 }
 
+/// A namespace served from a directory on disk — a package's own working
+/// tree, read in place. No ref, because there is nothing to check out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathSource {
+    /// The directory holding `<name>/<version>/` package trees.
+    pub root: PathBuf,
+    /// Path prefix inside it, the same meaning `RepoSource::subdir` has.
+    pub subdir: String,
+}
+
 /// Where one namespace resolves from. Exactly one variant per namespace: moving
 /// a project between a release and a branch is an explicit edit, not a
 /// precedence rule.
@@ -105,6 +116,7 @@ impl ReleasesSource {
 pub enum NamespaceSource {
     Repo(RepoSource),
     Releases(ReleasesSource),
+    Path(PathSource),
 }
 
 /// The `[packages.<ns>]` keys as written, before the one-of and ref-precedence
@@ -113,6 +125,7 @@ pub enum NamespaceSource {
 struct NamespaceSourceRaw {
     repo: Option<String>,
     releases: Option<String>,
+    path: Option<String>,
     branch: Option<String>,
     tag: Option<String>,
     rev: Option<String>,
@@ -163,17 +176,19 @@ impl NamespaceSource {
             ("subdir", raw.subdir.as_ref()),
         ];
 
-        match (raw.repo, raw.releases) {
-            (Some(_), Some(_)) => reject(
+        match (raw.repo, raw.releases, raw.path) {
+            (Some(_), Some(_), _) | (Some(_), _, Some(_)) | (_, Some(_), Some(_)) => reject(
                 namespace,
-                "set `repo` or `releases`, not both. Switching a project between a release and a \
-                 branch is an explicit edit, not a precedence rule",
+                "set exactly one of `repo` (a repository at a ref), `releases` (a releases host) \
+                 or `path` (a directory on disk). Switching a project between a release, a \
+                 branch and a local directory is an explicit edit, not a precedence rule",
             ),
-            (None, None) => reject(
+            (None, None, None) => reject(
                 namespace,
-                "set one of `repo` (a repository at a ref) or `releases` (a releases host)",
+                "set one of `repo` (a repository at a ref), `releases` (a releases host) or \
+                 `path` (a directory on disk)",
             ),
-            (None, Some(releases)) => {
+            (None, Some(releases), None) => {
                 if let Some((key, _)) = ref_keys.iter().find(|(_, value)| value.is_some()) {
                     return reject(
                         namespace,
@@ -187,11 +202,33 @@ impl NamespaceSource {
                     namespace, releases,
                 )?))
             }
-            (Some(url), None) => Ok(NamespaceSource::Repo(RepoSource {
+            (Some(url), None, None) => Ok(NamespaceSource::Repo(RepoSource {
                 url,
                 git_ref: Self::git_ref(namespace, raw.branch, raw.tag, raw.rev),
                 subdir: Self::subdir(namespace, raw.subdir)?,
             })),
+            (None, None, Some(path)) => {
+                let path_ref_keys = [
+                    ("branch", raw.branch.as_ref()),
+                    ("tag", raw.tag.as_ref()),
+                    ("rev", raw.rev.as_ref()),
+                ];
+                if let Some((key, _)) = path_ref_keys.iter().find(|(_, value)| value.is_some()) {
+                    return reject(
+                        namespace,
+                        format!(
+                            "`{key}` selects a ref inside a repository, and `path` reads a \
+                             directory in place, so there is no ref to select. Use \
+                             `repo = \"<path>\"` with `{key}` if you want a local repository AT \
+                             a ref."
+                        ),
+                    );
+                }
+                Ok(NamespaceSource::Path(PathSource {
+                    root: PathBuf::from(path),
+                    subdir: Self::subdir(namespace, raw.subdir)?,
+                }))
+            }
         }
     }
 
@@ -442,7 +479,7 @@ mod tests {
     fn repo_and_releases_together_are_rejected() {
         let msg = error("[packages.ns]\nrepo = \"u\"\nreleases = \"a/b\"");
         assert!(
-            msg.contains("[packages.ns]") && msg.contains("not both"),
+            msg.contains("[packages.ns]") && msg.contains("exactly one"),
             "{msg}"
         );
     }
@@ -482,6 +519,44 @@ mod tests {
             msg.contains("[packages.ns]") && msg.contains("relative"),
             "{msg}"
         );
+    }
+
+    #[test]
+    fn path_alone_parses() {
+        let NamespaceSource::Path(path) = source("[packages.ns]\npath = \"../pkgs\"", "ns") else {
+            panic!("expected a path source");
+        };
+        assert_eq!(path.root, std::path::PathBuf::from("../pkgs"));
+        assert_eq!(path.subdir, "");
+    }
+
+    #[test]
+    fn path_and_repo_together_are_rejected() {
+        let msg = error("[packages.ns]\npath = \"../pkgs\"\nrepo = \"u\"");
+        assert!(
+            msg.contains("[packages.ns]") && msg.contains("exactly one"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn path_and_branch_together_are_rejected() {
+        let msg = error("[packages.ns]\npath = \"../pkgs\"\nbranch = \"b\"");
+        assert!(
+            msg.contains("[packages.ns]") && msg.contains("branch") && msg.contains("repo"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn path_keeps_subdir() {
+        let NamespaceSource::Path(path) = source(
+            "[packages.ns]\npath = \"../pkgs\"\nsubdir = \"packages\"",
+            "ns",
+        ) else {
+            panic!("expected a path source");
+        };
+        assert_eq!(path.subdir, "packages");
     }
 
     #[test]

--- a/crates/core/src/packages/mod.rs
+++ b/crates/core/src/packages/mod.rs
@@ -117,6 +117,17 @@ impl PackageResolver {
         )
     }
 
+    /// Whether this namespace is served from a directory on disk.
+    ///
+    /// Unlike a repository ref (a sha-keyed cache directory) or a release (an
+    /// immutable, version-keyed cache directory), a `path` source's tree can
+    /// change while a watch is running — editing it is the whole point — so a
+    /// watch must cover it regardless of whether the package declares any
+    /// `[tool.rheo.*]` assets. See `Build::watch_asset_spec`.
+    pub fn is_path_backed(&self, namespace: &str) -> bool {
+        matches!(self.configured.get(namespace), Some(Backend::Path(_)))
+    }
+
     /// Whether rheo knows how to fetch this namespace ahead of the asset scan.
     ///
     /// A namespace rheo cannot fetch must stay skipped rather than attempting a

--- a/crates/core/src/packages/mod.rs
+++ b/crates/core/src/packages/mod.rs
@@ -15,8 +15,10 @@ use typst_kit::packages::SystemPackages;
 use crate::config::{NamespaceSource, ReleasesSource};
 
 mod git;
+mod path;
 
 pub use git::GitPackages;
+pub use path::PathPackages;
 
 /// The download base `@rheo` uses when no `[packages.rheo]` table overrides it.
 const REGISTRY_URL: &str = "https://github.com/freecomputinglab/rheo-packages/releases/download";
@@ -28,6 +30,7 @@ const USER_AGENT: &str = concat!("rheo/", env!("CARGO_PKG_VERSION"));
 enum Backend {
     Repo(GitPackages),
     Releases(RheoPackages),
+    Path(PathPackages),
 }
 
 /// Resolves a package spec to a directory on disk, routing by namespace.
@@ -56,6 +59,9 @@ impl PackageResolver {
                     NamespaceSource::Releases(releases) => {
                         Backend::Releases(RheoPackages::with_source(downloader(), releases.clone()))
                     }
+                    NamespaceSource::Path(path) => {
+                        Backend::Path(PathPackages::new(namespace, path.clone()))
+                    }
                 };
                 (namespace.clone(), backend)
             })
@@ -72,6 +78,7 @@ impl PackageResolver {
         match self.configured.get(spec.namespace.as_str()) {
             Some(Backend::Repo(repo)) => repo.obtain(spec),
             Some(Backend::Releases(releases)) => releases.obtain(spec),
+            Some(Backend::Path(path)) => path.obtain(spec),
             None if spec.namespace == "rheo" => self.rheo.obtain(spec),
             None => self.universe.obtain(spec),
         }
@@ -88,7 +95,7 @@ impl PackageResolver {
             .iter()
             .filter_map(|(namespace, backend)| match backend {
                 Backend::Repo(repo) => Some((namespace.clone(), repo.prune())),
-                Backend::Releases(_) => None,
+                Backend::Releases(_) | Backend::Path(_) => None,
             })
             .collect();
         pruned.sort_by(|a, b| a.0.cmp(&b.0));
@@ -100,11 +107,14 @@ impl PackageResolver {
         self.configured.contains_key(namespace)
     }
 
-    /// Whether this namespace is served from a repository ref rather than a
-    /// releases host. A ref carries no build output, so its packages use their
-    /// source-mode asset block.
-    pub fn is_repo_backed(&self, namespace: &str) -> bool {
-        matches!(self.configured.get(namespace), Some(Backend::Repo(_)))
+    /// Whether this namespace is served from a repository ref or a directory on
+    /// disk, rather than a releases host. Neither carries a build output, so
+    /// their packages use their source-mode asset block.
+    pub fn is_source_backed(&self, namespace: &str) -> bool {
+        matches!(
+            self.configured.get(namespace),
+            Some(Backend::Repo(_)) | Some(Backend::Path(_))
+        )
     }
 
     /// Whether rheo knows how to fetch this namespace ahead of the asset scan.

--- a/crates/core/src/packages/path.rs
+++ b/crates/core/src/packages/path.rs
@@ -1,0 +1,115 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use ecow::eco_format;
+use tracing::info;
+use typst_kit::files::FsRoot;
+use typst_library::diag::{PackageError, PackageResult};
+use typst_syntax::package::PackageSpec;
+
+use crate::config::PathSource;
+
+/// Serves a namespace from a directory on disk — a package's own working tree,
+/// read in place. No caching and no sha: the tree IS the source, so an edit
+/// shows up on the next build.
+pub struct PathPackages {
+    namespace: String,
+    source: PathSource,
+    announced: AtomicBool,
+}
+
+impl PathPackages {
+    pub fn new(namespace: &str, source: PathSource) -> Self {
+        Self {
+            namespace: namespace.to_string(),
+            source,
+            announced: AtomicBool::new(false),
+        }
+    }
+
+    /// The directory for `@<ns>/<name>:<version>` inside the configured root.
+    pub fn obtain(&self, spec: &PackageSpec) -> PackageResult<FsRoot> {
+        if !self.announced.swap(true, Ordering::Relaxed) {
+            info!(
+                "@{} resolves from {} (a directory on disk)",
+                self.namespace,
+                self.source.root.display(),
+            );
+        }
+
+        let mut dir = self.source.root.clone();
+        if !self.source.subdir.is_empty() {
+            dir.push(&self.source.subdir);
+        }
+        dir.push(spec.name.as_str());
+        dir.push(spec.version.to_string());
+
+        if !dir.exists() {
+            return Err(PackageError::Other(Some(eco_format!(
+                "@{namespace}/{name}:{version} not found at {dir}",
+                namespace = self.namespace,
+                name = spec.name,
+                version = spec.version,
+                dir = dir.display(),
+            ))));
+        }
+        Ok(FsRoot::new(dir))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(name: &str, version: &str) -> PackageSpec {
+        format!("@demo/{name}:{version}").parse().unwrap()
+    }
+
+    #[test]
+    fn obtain_returns_the_directory_when_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("demo/0.1.0");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("typst.toml"), "[package]\n").unwrap();
+
+        let packages = PathPackages::new(
+            "demo",
+            PathSource {
+                root: tmp.path().to_path_buf(),
+                subdir: String::new(),
+            },
+        );
+        let root = packages.obtain(&spec("demo", "0.1.0")).expect("obtain");
+        assert!(root.path().join("typst.toml").exists());
+    }
+
+    #[test]
+    fn obtain_errors_naming_the_expected_path_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let packages = PathPackages::new(
+            "demo",
+            PathSource {
+                root: tmp.path().to_path_buf(),
+                subdir: String::new(),
+            },
+        );
+        let err = format!("{:?}", packages.obtain(&spec("demo", "0.2.0")).unwrap_err());
+        assert!(err.contains(&tmp.path().join("demo/0.2.0").to_string_lossy().to_string()));
+    }
+
+    #[test]
+    fn subdir_is_applied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("packages/demo/0.1.0");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("typst.toml"), "[package]\n").unwrap();
+
+        let packages = PathPackages::new(
+            "demo",
+            PathSource {
+                root: tmp.path().to_path_buf(),
+                subdir: "packages".to_string(),
+            },
+        );
+        assert!(packages.obtain(&spec("demo", "0.1.0")).is_ok());
+    }
+}

--- a/crates/core/src/plugins/typst_manifest.rs
+++ b/crates/core/src/plugins/typst_manifest.rs
@@ -383,6 +383,21 @@ impl PackageIndex {
             .collect()
     }
 
+    /// Every resolved package's namespace and source directory, independent of
+    /// whether it declares any `[tool.rheo.*]` assets — unlike
+    /// [`manifest_assets`](Self::manifest_assets), which only ever sees a
+    /// package that declares one. The watcher needs this wider view: a
+    /// `path`-backed package's tree must be watched whether or not it ships an
+    /// asset block.
+    pub fn source_roots(&self) -> impl Iterator<Item = (&str, &Path)> {
+        self.resolved.iter().filter_map(|entry| {
+            Some((
+                entry.pkg.namespace.as_deref()?,
+                entry.pkg.source_root.as_path(),
+            ))
+        })
+    }
+
     /// Reject a package that came from a ref, declares no source-mode block, and
     /// whose declared scripts are the `dist/` output that no ref carries.
     ///

--- a/crates/core/src/plugins/typst_manifest.rs
+++ b/crates/core/src/plugins/typst_manifest.rs
@@ -357,7 +357,7 @@ impl PackageIndex {
                 let source_mode = pkg
                     .namespace
                     .as_deref()
-                    .is_some_and(|ns| resolver.is_repo_backed(ns));
+                    .is_some_and(|ns| resolver.is_source_backed(ns));
                 Some(IndexEntry {
                     spec: spec.clone(),
                     pkg,


### PR DESCRIPTION
For more rapid development cycles on packages, you can now do the following in rheo.toml (rather than needing to push the custom package namespace to a branch on a remote):

```toml
[packages.rookery]
repo = "/home/lox/code/_rheo/rookery"
branch = "0.1.0"
```