### PR TITLE
Fix the Nix flake package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/freecomputinglab/rheo"
 readme = "README.md"
 
+[workspace.metadata.crane]
+name = "rheo"
+
 [workspace.lints.rust]
 unexpected_cfgs = "warn"
 

--- a/crates/core/src/reticulate/mould.rs
+++ b/crates/core/src/reticulate/mould.rs
@@ -169,6 +169,7 @@ mod tests {
         assert_eq!(rewrites.apply("unchanged"), "unchanged");
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "must not overlap")]
     fn overlapping_rewrites_panic_in_debug() {

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
             pkg-config
             perl
             rustToolchain
+            git
           ];
         };
 


### PR DESCRIPTION
Trying to build with Nix previously caused 3 problems:

1. During testing, Git was assumed to be in path but not specified in the derivations dependencies, resulting in build failures. (Nix-specific issue)
2. During Nix evaluation, crane expects to be able to name the derivation from parsing the Cargo.toml, but no name was present. (Nix-specific issue)
3. During testing, the `overlapping_rewrites_panic_in_debug` assumed debug assertions, but they are disabled on release mode by default. This caused the test not to panic, thus failing. (general issue that affects the Nix build)

This pull request solves these. I structured it in 1 commit per solution, but I can squash them if preferred by the maintainers.